### PR TITLE
keep decode result when pannel is hidden

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
+				"${workspaceFolder}/dist/extension.js"
 			],
 			"preLaunchTask": "${defaultBuildTask}"
 		},
@@ -28,7 +28,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/test/**/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "test-compile"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,15 +5,26 @@
 	"tasks": [
 		{
 			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"isBackground": true,
+			"script": "webpack",
+			"isBackground": false,
 			"presentation": {
-				"reveal": "never"
+				"echo": true,
+				"reveal": "always",
 			},
 			"group": {
 				"kind": "build",
 				"isDefault": true
+			}
+		},
+		{
+			"label": "test-compile",
+			"type": "npm",
+			"script": "test-compile",
+			"problemMatcher": "$tsc",
+			"isBackground": false,
+			"presentation": {
+				"echo": true,
+				"reveal": "always",
 			}
 		}
 	]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Change Log
 
-## 1.1.1 - 2021-02-07
-### Changed 
-- Use Webpack for build
+## 1.2.0 - 2021-02-08  
+### Changed  
+- Keep decode result when pannel is hidden
+- hidden seek-bar until finish decoding    
 
-### Added
-- SeekBar
+## 1.1.1 - 2021-02-07  
+### Changed  
+- Use Webpack for build  
 
-## 1.0.3 - 2020-12-26
-### Added 
-- LICENSE
+### Added  
+- SeekBar  
 
-## 1.0.0 - 2020-12-05
-- Initial release
+## 1.0.3 - 2020-12-26  
+### Added  
+- LICENSE  
+
+## 1.0.0 - 2020-12-05  
+- Initial release  

--- a/media/audioPreview.css
+++ b/media/audioPreview.css
@@ -18,7 +18,7 @@ button {
 }
 
 input[type="range"] {
-    display: block;
+    display: none;
     width: 60%;
     max-width: 500px;
     margin: 1em;

--- a/media/audioPreview.js
+++ b/media/audioPreview.js
@@ -101,7 +101,7 @@ class Player {
             // create audio buffer because
             // passed audioBuffer is once stringified(?), 
             // and it isn't recognised as an AudioBuffer when you set it by `source.buffer = audioBuffer`
-            const ac = new AudioContext();
+            const ac = new AudioContext({ sampleRate: audioBuffer.sampleRate });
             const ab = ac.createBuffer(audioBuffer.numberOfChannels, audioBuffer.length, audioBuffer.sampleRate);
             for (let ch = 0; ch < ab.numberOfChannels; ch++) {
                 const f32a = new Float32Array(ab.length);
@@ -111,7 +111,7 @@ class Player {
                 ab.copyToChannel(f32a, ch);
             }
 
-            //set player ui
+            // set player ui
             new Player(ac, ab, audioBuffer.duration);
         } catch (err) {
             message.textContent = "failed to prepare audioBufferSourceNode: " + err;

--- a/media/audioPreview.js
+++ b/media/audioPreview.js
@@ -15,6 +15,7 @@ class Player {
         };
 
         this.seekBar = document.getElementById("seek-bar");
+        this.seekBar.style.display = "block";
         this.seekBar.value = 0;
         this.seekBar.onchange = () => { this.onChange(); };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "wav-preview",
 	"displayName": "wav-preview",
 	"description": "preview and play wav file in VS Code",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"engines": {
 		"vscode": "^1.51.0"
 	},

--- a/src/audioPreviewEditor.ts
+++ b/src/audioPreviewEditor.ts
@@ -66,7 +66,10 @@ export class AudioPreviewEditorProvider implements vscode.CustomReadonlyEditorPr
             AudioPreviewEditorProvider.viewType,
             new AudioPreviewEditorProvider(context),
             {
-                supportsMultipleEditorsPerDocument: false
+                supportsMultipleEditorsPerDocument: false,
+                webviewOptions: {
+                    retainContextWhenHidden: true,
+                }
             }
         );
     }


### PR DESCRIPTION
keep decode result to avoid re-decoding when webview pannel is hidden