### PR TITLE
Feature player filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,41 @@ You can configure default value of player settings like example below.
     default: true
     */
     "enableSeekToPlay": true,
+
+    /*
+    Enable high-pass filter on playback.
+    true: enable high-pass filter, false: disable high-pass filter
+    default: false
+    */
+    "enableHpf": true,
+
+    /*
+    Cut off frequency for the high-pass filter in Hz. [10, sampleRate/2]
+    default: 100
+    */
+    "hpfFrequency": 100,
+
+    /*
+    Enable low-pass filter on playback.
+    true: enable low-pass filter, false: disable low-pass filter
+    default: false
+    */
+    "enableLpf": true,
+
+    /*
+    Cut off frequency for the low-pass filter in Hz. [10, sampleRate/2]
+    default: 100
+    */
+    "lpfFrequency": 10000,
+
+    /*
+    Match the filter frequencies to the frequency range of the analyzer.
+    Note that if this option is set to true, hpfFrequency and lpfFrequency is overridden by spectrogram frequency range settings.
+    true: automatically match the filter frequencies to the analyzer's frequency range
+    false: filter frequencies can be set independently of the analyzer's frequency range
+    default: false
+    */
+    "matchFilterFrequencyToSpectrogram": true,
 }
 ```
 

--- a/src/__mocks__/helper.ts
+++ b/src/__mocks__/helper.ts
@@ -114,6 +114,7 @@ export class MockAudioBuffer {
 
 class MockAudioNode {
   connect() {}
+  disconnect() {}
 }
 
 class MockAudioParam {
@@ -126,6 +127,17 @@ class MockGainNode extends MockAudioNode {
   constructor() {
     super();
     this.gain = { value: 1 };
+  }
+}
+
+class MockBiquadFilterNode extends MockAudioNode {
+  frequency: MockAudioParam;
+  Q: MockAudioParam;
+
+  constructor() {
+    super();
+    this.frequency = { value: 1000 };
+    this.Q = { value: 1.0 };
   }
 }
 
@@ -164,6 +176,10 @@ class MockAudioContext extends MockAudioNode {
 
   createGain() {
     return new MockGainNode();
+  }
+
+  createBiquadFilter() {
+    return new MockBiquadFilterNode();
   }
 }
 

--- a/src/__mocks__/helper.ts
+++ b/src/__mocks__/helper.ts
@@ -132,7 +132,7 @@ class MockGainNode extends MockAudioNode {
 
 class MockBiquadFilterNode extends MockAudioNode {
   frequency: MockAudioParam;
-  Q: MockAudioParam;    // eslint-disable-line
+  Q: MockAudioParam; // eslint-disable-line
 
   constructor() {
     super();

--- a/src/__mocks__/helper.ts
+++ b/src/__mocks__/helper.ts
@@ -132,7 +132,7 @@ class MockGainNode extends MockAudioNode {
 
 class MockBiquadFilterNode extends MockAudioNode {
   frequency: MockAudioParam;
-  Q: MockAudioParam;
+  Q: MockAudioParam;    // eslint-disable-line
 
   constructor() {
     super();

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,11 @@ export interface PlayerDefault {
   initialVolume: number;
   enableSpacekeyPlay: boolean;
   enableSeekToPlay: boolean;
+  enableHpf: boolean;
+  hpfFrequency: number;
+  enableLpf: boolean;
+  lpfFrequency: number;
+  matchFilterFrequencyToSpectrogram: boolean;
 }
 
 export interface AnalyzeDefault {

--- a/src/util.ts
+++ b/src/util.ts
@@ -51,6 +51,23 @@ export function getValueInRange(
   return targetValue;
 }
 
+export function getLimitedValueInRange(
+  targetValue: number,
+  validMin: number,
+  validMax: number,
+  defaultValue: number
+): number {
+  if (!Number.isFinite(targetValue)) {
+    return defaultValue;
+  } else if (validMax < targetValue) {
+    return validMax;
+  } else if(targetValue < validMin) {
+    return validMin;
+  }
+
+  return targetValue;
+}
+
 export function getValueInEnum(
   targetValue: number,
   enumType,

--- a/src/util.ts
+++ b/src/util.ts
@@ -55,13 +55,13 @@ export function getLimitedValueInRange(
   targetValue: number,
   validMin: number,
   validMax: number,
-  defaultValue: number
+  defaultValue: number,
 ): number {
   if (!Number.isFinite(targetValue)) {
     return defaultValue;
   } else if (validMax < targetValue) {
     return validMax;
-  } else if(targetValue < validMin) {
+  } else if (targetValue < validMin) {
     return validMin;
   }
 

--- a/src/webview/components/analyzer/analyzerComponent.test.ts
+++ b/src/webview/components/analyzer/analyzerComponent.test.ts
@@ -39,6 +39,11 @@ describe("analyserComponent", () => {
       initialVolume: 1.0,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
@@ -104,6 +109,11 @@ describe("auto analyze", () => {
       initialVolume: 1.0,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
@@ -150,6 +160,11 @@ describe("auto analyze", () => {
       initialVolume: 1.0,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
@@ -203,6 +218,11 @@ describe("position of seek-bar should be updated when recieving update-seekbar e
       initialVolume: 1.0,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);

--- a/src/webview/components/analyzer/analyzerComponent.test.ts
+++ b/src/webview/components/analyzer/analyzerComponent.test.ts
@@ -45,8 +45,15 @@ describe("analyserComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    const playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingsService,
+    );
     analyzerComponent = new AnalyzerComponent(
       "#analyzer",
       audioBuffer,
@@ -115,8 +122,15 @@ describe("auto analyze", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    const playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingsService,
+    );
     const ac = new AnalyzerComponent(
       "#analyzer",
       audioBuffer,
@@ -166,8 +180,15 @@ describe("auto analyze", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    const playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingsService,
+    );
     const ac = new AnalyzerComponent(
       "#analyzer",
       audioBuffer,
@@ -224,8 +245,15 @@ describe("position of seek-bar should be updated when recieving update-seekbar e
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingsService,
+    );
     analyzeSettingsService.minTime = 2;
     analyzeSettingsService.maxTime = 6;
     // audio: 10s, minTime: 2s, maxTime: 6s

--- a/src/webview/components/analyzer/analyzerComponent.test.ts
+++ b/src/webview/components/analyzer/analyzerComponent.test.ts
@@ -45,7 +45,7 @@ describe("analyserComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
     analyzerComponent = new AnalyzerComponent(
       "#analyzer",
@@ -115,7 +115,7 @@ describe("auto analyze", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
     const ac = new AnalyzerComponent(
       "#analyzer",
@@ -166,7 +166,7 @@ describe("auto analyze", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
     const ac = new AnalyzerComponent(
       "#analyzer",
@@ -224,7 +224,7 @@ describe("position of seek-bar should be updated when recieving update-seekbar e
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
     analyzeSettingsService.minTime = 2;
     analyzeSettingsService.maxTime = 6;

--- a/src/webview/components/player/playerComponent.test.ts
+++ b/src/webview/components/player/playerComponent.test.ts
@@ -21,6 +21,11 @@ describe("playerComponent", () => {
       initialVolume: 1.0,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
@@ -104,6 +109,11 @@ describe("playerComponent", () => {
       initialVolume: 1.0,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
@@ -178,6 +188,11 @@ describe("playerComponent", () => {
       initialVolume: 1.0,
       enableSpacekeyPlay: false,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
     const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);

--- a/src/webview/components/player/playerComponent.test.ts
+++ b/src/webview/components/player/playerComponent.test.ts
@@ -27,7 +27,7 @@ describe("playerComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
     playerComponent = new PlayerComponent(
       "#player",
@@ -115,7 +115,7 @@ describe("playerComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
     const playerComponent = new PlayerComponent(
       "#player2",
@@ -194,7 +194,7 @@ describe("playerComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
     const playerComponent = new PlayerComponent(
       "#player2",

--- a/src/webview/components/player/playerComponent.test.ts
+++ b/src/webview/components/player/playerComponent.test.ts
@@ -27,8 +27,15 @@ describe("playerComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingService,
+    );
     playerComponent = new PlayerComponent(
       "#player",
       playerService,
@@ -115,8 +122,15 @@ describe("playerComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
+    const playerSettingService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    const playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingService,
+    );
     const playerComponent = new PlayerComponent(
       "#player2",
       playerService,
@@ -194,8 +208,15 @@ describe("playerComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    const playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
+    const playerSettingService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    const playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingService,
+    );
     const playerComponent = new PlayerComponent(
       "#player2",
       playerService,

--- a/src/webview/components/player/playerComponent.ts
+++ b/src/webview/components/player/playerComponent.ts
@@ -9,21 +9,21 @@ export default class PlayerComponent extends Component {
   private _playButton: HTMLButtonElement;
   private _volumeBar: HTMLInputElement;
   private _playerService: PlayerService;
-  private _playerSettingService: PlayerSettingsService;
+  private _playerSettingsService: PlayerSettingsService;
 
   constructor(
     componentRootID: string,
     playerService: PlayerService,
-    playerSettingService: PlayerSettingsService,
+    playerSettingsService: PlayerSettingsService,
   ) {
     super();
     this._playerService = playerService;
-    this._playerSettingService = playerSettingService;
+    this._playerSettingsService = playerSettingsService;
 
     // init base html
     this._componentRoot = document.querySelector(componentRootID);
 
-    const volumeBar = this._playerSettingService.volumeUnitDb
+    const volumeBar = this._playerSettingsService.volumeUnitDb
       ? `<div class="volumeText">volume 0.0 dB</div>
              <input type="range" class="volumeBar" value="0" min="-80" max="0" step="0.5">`
       : `<div class="volumeText">volume 100</div>
@@ -80,7 +80,7 @@ export default class PlayerComponent extends Component {
       this._componentRoot.querySelector(".volumeText")
     );
     const updateVolume = () => {
-      if (this._playerSettingService.volumeUnitDb) {
+      if (this._playerSettingsService.volumeUnitDb) {
         // convert dB setting to linear gain
         // -80 dB is treated as mute
         const voldb = Number(this._volumeBar.value);
@@ -96,9 +96,9 @@ export default class PlayerComponent extends Component {
     };
     this._addEventlistener(this._volumeBar, EventType.INPUT, updateVolume);
     this._volumeBar.value = String(
-      this._playerSettingService.volumeUnitDb
-        ? this._playerSettingService.initialVolumeDb
-        : this._playerSettingService.initialVolume,
+      this._playerSettingsService.volumeUnitDb
+        ? this._playerSettingsService.initialVolumeDb
+        : this._playerSettingsService.initialVolume,
     );
     updateVolume();
 
@@ -129,7 +129,7 @@ export default class PlayerComponent extends Component {
 
     // register keyboard shortcuts
     // don't use command.register at audioPreviewEditorProvider.openCustomDocument due to command confliction
-    if (this._playerSettingService.enableSpacekeyPlay) {
+    if (this._playerSettingsService.enableSpacekeyPlay) {
       this._addEventlistener(window, EventType.KEY_DOWN, (e: KeyboardEvent) => {
         if (e.isComposing || e.code !== "Space") {
           return;

--- a/src/webview/components/playerSettings/playerSettingsComponent.css
+++ b/src/webview/components/playerSettings/playerSettingsComponent.css
@@ -1,0 +1,9 @@
+.playerSetting {
+  margin: 0.5em;
+}
+
+.playerSetting__input {
+  width: auto;
+  display: inline-block;
+  margin: 0.5em;
+}

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -50,7 +50,7 @@ describe("playerSettingsComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
+    playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
     playerSettingsComponent = new PlayerSettingsComponent(
       "#playerSettings",

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -105,7 +105,7 @@ describe("playerSettingsComponent", () => {
       ".js-playerSetting-hpfFrequency",
     ) as HTMLInputElement;
     hpfFrequencyInput.value = hpfFrequency.toString();
-    hpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
+    hpfFrequencyInput.dispatchEvent(new Event(EventType.CHANGE));
     expect(playerSettingsService.hpfFrequency).toBeCloseTo(hpfFrequency);
   });
   test("hpf-frequency-input should be updated when recieving update-hpf-frequency event", () => {
@@ -164,7 +164,7 @@ describe("playerSettingsComponent", () => {
       ".js-playerSetting-lpfFrequency",
     ) as HTMLInputElement;
     lpfFrequencyInput.value = lpfFrequency.toString();
-    lpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
+    lpfFrequencyInput.dispatchEvent(new Event(EventType.CHANGE));
     expect(playerSettingsService.lpfFrequency).toBeCloseTo(lpfFrequency);
   });
   test("lpf-frequency-input should be updated when recieving update-lpf-frequency event", () => {

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -65,7 +65,9 @@ describe("playerSettingsComponent", () => {
   });
 
   test("enable-hpf should be updated when user change enable-hpf-input", () => {
-    const enableHpf = document.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
+    const enableHpf = document.querySelector(
+      ".js-playerSetting-enableHpf",
+    ) as HTMLInputElement;
     enableHpf.checked = true;
     enableHpf.dispatchEvent(new Event(EventType.CHANGE));
     expect(playerSettingsService.enableHpf).toBe(true);
@@ -82,7 +84,9 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const enableHpf = document.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
+    const enableHpf = document.querySelector(
+      ".js-playerSetting-enableHpf",
+    ) as HTMLInputElement;
     expect(enableHpf.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(
@@ -97,7 +101,9 @@ describe("playerSettingsComponent", () => {
 
   test("hpf-frequency should be updated when user change hpf-frequency-input", () => {
     const hpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
-    const hpfFrequencyInput = document.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
+    const hpfFrequencyInput = document.querySelector(
+      ".js-playerSetting-hpfFrequency",
+    ) as HTMLInputElement;
     hpfFrequencyInput.value = hpfFrequency.toString();
     hpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
     expect(playerSettingsService.hpfFrequency).toBeCloseTo(hpfFrequency);
@@ -111,12 +117,16 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const hpfFrequencyInput = document.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
+    const hpfFrequencyInput = document.querySelector(
+      ".js-playerSetting-hpfFrequency",
+    ) as HTMLInputElement;
     expect(Number(hpfFrequencyInput.value)).toBeCloseTo(hpfFrequency);
   });
 
   test("enable-lpf should be updated when user change enable-lpf-input", () => {
-    const enableLpf = document.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
+    const enableLpf = document.querySelector(
+      ".js-playerSetting-enableLpf",
+    ) as HTMLInputElement;
     enableLpf.checked = true;
     enableLpf.dispatchEvent(new Event(EventType.CHANGE));
     expect(playerSettingsService.enableLpf).toBe(true);
@@ -133,7 +143,9 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const enableLpf = document.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
+    const enableLpf = document.querySelector(
+      ".js-playerSetting-enableLpf",
+    ) as HTMLInputElement;
     expect(enableLpf.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(
@@ -148,7 +160,9 @@ describe("playerSettingsComponent", () => {
 
   test("lpf-frequency should be updated when user change lpf-frequency-input", () => {
     const lpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
-    const lpfFrequencyInput = document.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
+    const lpfFrequencyInput = document.querySelector(
+      ".js-playerSetting-lpfFrequency",
+    ) as HTMLInputElement;
     lpfFrequencyInput.value = lpfFrequency.toString();
     lpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
     expect(playerSettingsService.lpfFrequency).toBeCloseTo(lpfFrequency);
@@ -162,15 +176,16 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const lpfFrequencyInput = document.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
+    const lpfFrequencyInput = document.querySelector(
+      ".js-playerSetting-lpfFrequency",
+    ) as HTMLInputElement;
     expect(Number(lpfFrequencyInput.value)).toBeCloseTo(lpfFrequency);
   });
 
   test("match-filter-frequency-to-spectrogram should be updated when user change match-filter-frequency-to-spectrogram-input", () => {
-    const matchFilterFrequencyToSpectrogram =
-      document.querySelector(
-        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
-      ) as HTMLInputElement;
+    const matchFilterFrequencyToSpectrogram = document.querySelector(
+      ".js-playerSetting-matchFilterFrequencyToSpectrogram",
+    ) as HTMLInputElement;
     matchFilterFrequencyToSpectrogram.checked = true;
     matchFilterFrequencyToSpectrogram.dispatchEvent(
       new Event(EventType.CHANGE),
@@ -194,10 +209,9 @@ describe("playerSettingsComponent", () => {
         },
       ),
     );
-    const matchFilterFrequencyToSpectrogram =
-      document.querySelector(
-        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
-      ) as HTMLInputElement;
+    const matchFilterFrequencyToSpectrogram = document.querySelector(
+      ".js-playerSetting-matchFilterFrequencyToSpectrogram",
+    ) as HTMLInputElement;
     expect(matchFilterFrequencyToSpectrogram.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -1,7 +1,4 @@
-import {
-  createAudioContext,
-  getRandomFloat,
-} from "../../../__mocks__/helper";
+import { createAudioContext, getRandomFloat } from "../../../__mocks__/helper";
 import { EventType } from "../../events";
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
@@ -50,8 +47,15 @@ describe("playerSettingsComponent", () => {
       lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
-    playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
+    playerSettingsService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    const playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingsService,
+    );
     playerSettingsComponent = new PlayerSettingsComponent(
       "#playerSettings",
       playerService,
@@ -187,35 +191,49 @@ describe("playerSettingsComponent", () => {
 
   test("match-filter-frequency-to-spectrogram should be updated when user change match-filter-frequency-to-spectrogram-input", () => {
     const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-matchFilterFrequencyToSpectrogram")
+      document.querySelector(
+        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
+      )
     );
     matchFilterFrequencyToSpectrogram.checked = true;
-    matchFilterFrequencyToSpectrogram.dispatchEvent(new Event(EventType.CHANGE));
+    matchFilterFrequencyToSpectrogram.dispatchEvent(
+      new Event(EventType.CHANGE),
+    );
     expect(playerSettingsService.matchFilterFrequencyToSpectrogram).toBe(true);
 
     matchFilterFrequencyToSpectrogram.checked = false;
-    matchFilterFrequencyToSpectrogram.dispatchEvent(new Event(EventType.CHANGE));
+    matchFilterFrequencyToSpectrogram.dispatchEvent(
+      new Event(EventType.CHANGE),
+    );
     expect(playerSettingsService.matchFilterFrequencyToSpectrogram).toBe(false);
   });
   test("match-filter-frequency-to-spectrogram should be updated when recieving update-match-filter-frequency-to-spectrogram event", () => {
     playerSettingsService.dispatchEvent(
-      new CustomEvent(EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM, {
-        detail: {
-          value: true,
+      new CustomEvent(
+        EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
+        {
+          detail: {
+            value: true,
+          },
         },
-      }),
+      ),
     );
     const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-matchFilterFrequencyToSpectrogram")
+      document.querySelector(
+        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
+      )
     );
     expect(matchFilterFrequencyToSpectrogram.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(
-      new CustomEvent(EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM, {
-        detail: {
-          value: false,
+      new CustomEvent(
+        EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
+        {
+          detail: {
+            value: false,
+          },
         },
-      }),
+      ),
     );
     expect(matchFilterFrequencyToSpectrogram.checked).toBe(false);
   });

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -72,9 +72,7 @@ describe("playerSettingsComponent", () => {
   });
 
   test("enable-hpf should be updated when user change enable-hpf-input", () => {
-    const enableHpf = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-enableHpf")
-    );
+    const enableHpf = document.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
     enableHpf.checked = true;
     enableHpf.dispatchEvent(new Event(EventType.CHANGE));
     expect(playerSettingsService.enableHpf).toBe(true);
@@ -91,9 +89,7 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const enableHpf = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-enableHpf")
-    );
+    const enableHpf = document.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
     expect(enableHpf.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(
@@ -108,9 +104,7 @@ describe("playerSettingsComponent", () => {
 
   test("hpf-frequency should be updated when user change hpf-frequency-input", () => {
     const hpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
-    const hpfFrequencyInput = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-hpfFrequency")
-    );
+    const hpfFrequencyInput = document.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
     hpfFrequencyInput.value = hpfFrequency.toString();
     hpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
     expect(playerSettingsService.hpfFrequency).toBeCloseTo(hpfFrequency);
@@ -124,16 +118,12 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const hpfFrequencyInput = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-hpfFrequency")
-    );
+    const hpfFrequencyInput = document.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
     expect(Number(hpfFrequencyInput.value)).toBeCloseTo(hpfFrequency);
   });
 
   test("enable-lpf should be updated when user change enable-lpf-input", () => {
-    const enableLpf = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-enableLpf")
-    );
+    const enableLpf = document.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
     enableLpf.checked = true;
     enableLpf.dispatchEvent(new Event(EventType.CHANGE));
     expect(playerSettingsService.enableLpf).toBe(true);
@@ -150,9 +140,7 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const enableLpf = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-enableLpf")
-    );
+    const enableLpf = document.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
     expect(enableLpf.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(
@@ -167,9 +155,7 @@ describe("playerSettingsComponent", () => {
 
   test("lpf-frequency should be updated when user change lpf-frequency-input", () => {
     const lpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
-    const lpfFrequencyInput = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-lpfFrequency")
-    );
+    const lpfFrequencyInput = document.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
     lpfFrequencyInput.value = lpfFrequency.toString();
     lpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
     expect(playerSettingsService.lpfFrequency).toBeCloseTo(lpfFrequency);
@@ -183,18 +169,15 @@ describe("playerSettingsComponent", () => {
         },
       }),
     );
-    const lpfFrequencyInput = <HTMLInputElement>(
-      document.querySelector(".js-playerSetting-lpfFrequency")
-    );
+    const lpfFrequencyInput = document.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
     expect(Number(lpfFrequencyInput.value)).toBeCloseTo(lpfFrequency);
   });
 
   test("match-filter-frequency-to-spectrogram should be updated when user change match-filter-frequency-to-spectrogram-input", () => {
-    const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
+    const matchFilterFrequencyToSpectrogram =
       document.querySelector(
         ".js-playerSetting-matchFilterFrequencyToSpectrogram",
-      )
-    );
+      ) as HTMLInputElement;
     matchFilterFrequencyToSpectrogram.checked = true;
     matchFilterFrequencyToSpectrogram.dispatchEvent(
       new Event(EventType.CHANGE),
@@ -218,11 +201,10 @@ describe("playerSettingsComponent", () => {
         },
       ),
     );
-    const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
+    const matchFilterFrequencyToSpectrogram =
       document.querySelector(
         ".js-playerSetting-matchFilterFrequencyToSpectrogram",
-      )
-    );
+      ) as HTMLInputElement;
     expect(matchFilterFrequencyToSpectrogram.checked).toBe(true);
 
     playerSettingsService.dispatchEvent(

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -1,0 +1,222 @@
+import {
+  createAudioContext,
+  getRandomFloat,
+} from "../../../__mocks__/helper";
+import { EventType } from "../../events";
+import AnalyzeService from "../../services/analyzeService";
+import AnalyzeSettingsService from "../../services/analyzeSettingsService";
+import PlayerService from "../../services/playerService";
+import PlayerSettingsService from "../../services/playerSettingsService";
+import PlayerSettingsComponent from "./playerSettingsComponent";
+
+describe("playerSettingsComponent", () => {
+  let audioBuffer: AudioBuffer;
+  let analyzeService: AnalyzeService;
+  let analyzeSettingsService: AnalyzeSettingsService;
+  let playerSettingsService: PlayerSettingsService;
+  let playerSettingsComponent: PlayerSettingsComponent;
+  beforeAll(() => {
+    document.body.innerHTML = '<div id="playerSettings"></div>';
+    const audioContext = createAudioContext(44100);
+    audioBuffer = audioContext.createBuffer(2, 44100, 44100);
+    const ad = {
+      waveformVisible: undefined,
+      waveformVerticalScale: undefined,
+      spectrogramVisible: undefined,
+      spectrogramVerticalScale: undefined,
+      windowSizeIndex: undefined,
+      minAmplitude: undefined,
+      maxAmplitude: undefined,
+      minFrequency: undefined,
+      maxFrequency: undefined,
+      spectrogramAmplitudeRange: undefined,
+      frequencyScale: undefined,
+      melFilterNum: undefined,
+    };
+    analyzeService = new AnalyzeService(audioBuffer);
+    analyzeSettingsService = AnalyzeSettingsService.fromDefaultSetting(
+      ad,
+      audioBuffer,
+    );
+    const pd = {
+      volumeUnitDb: true,
+      initialVolumeDb: 0.0,
+      initialVolume: 1.0,
+      enableSpacekeyPlay: true,
+      enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
+    };
+    playerSettingsService = PlayerSettingsService.fromDefaultSetting(pd);
+    const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
+    playerSettingsComponent = new PlayerSettingsComponent(
+      "#playerSettings",
+      playerService,
+      playerSettingsService,
+      analyzeService,
+      analyzeSettingsService,
+    );
+  });
+
+  afterAll(() => {
+    analyzeService.dispose();
+    analyzeSettingsService.dispose();
+    playerSettingsComponent.dispose();
+  });
+
+  test("enable-hpf should be updated when user change enable-hpf-input", () => {
+    const enableHpf = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-enableHpf")
+    );
+    enableHpf.checked = true;
+    enableHpf.dispatchEvent(new Event(EventType.CHANGE));
+    expect(playerSettingsService.enableHpf).toBe(true);
+
+    enableHpf.checked = false;
+    enableHpf.dispatchEvent(new Event(EventType.CHANGE));
+    expect(playerSettingsService.enableHpf).toBe(false);
+  });
+  test("enable-hpf should be updated when recieving update-enable-hpf event", () => {
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_ENABLE_HPF, {
+        detail: {
+          value: true,
+        },
+      }),
+    );
+    const enableHpf = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-enableHpf")
+    );
+    expect(enableHpf.checked).toBe(true);
+
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_ENABLE_HPF, {
+        detail: {
+          value: false,
+        },
+      }),
+    );
+    expect(enableHpf.checked).toBe(false);
+  });
+
+  test("hpf-frequency should be updated when user change hpf-frequency-input", () => {
+    const hpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
+    const hpfFrequencyInput = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-hpfFrequency")
+    );
+    hpfFrequencyInput.value = hpfFrequency.toString();
+    hpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
+    expect(playerSettingsService.hpfFrequency).toBeCloseTo(hpfFrequency);
+  });
+  test("hpf-frequency-input should be updated when recieving update-hpf-frequency event", () => {
+    const hpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_HPF_FREQUENCY, {
+        detail: {
+          value: hpfFrequency,
+        },
+      }),
+    );
+    const hpfFrequencyInput = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-hpfFrequency")
+    );
+    expect(Number(hpfFrequencyInput.value)).toBeCloseTo(hpfFrequency);
+  });
+
+  test("enable-lpf should be updated when user change enable-lpf-input", () => {
+    const enableLpf = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-enableLpf")
+    );
+    enableLpf.checked = true;
+    enableLpf.dispatchEvent(new Event(EventType.CHANGE));
+    expect(playerSettingsService.enableLpf).toBe(true);
+
+    enableLpf.checked = false;
+    enableLpf.dispatchEvent(new Event(EventType.CHANGE));
+    expect(playerSettingsService.enableLpf).toBe(false);
+  });
+  test("enable-lpf should be updated when recieving update-enable-lpf event", () => {
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_ENABLE_LPF, {
+        detail: {
+          value: true,
+        },
+      }),
+    );
+    const enableLpf = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-enableLpf")
+    );
+    expect(enableLpf.checked).toBe(true);
+
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_ENABLE_LPF, {
+        detail: {
+          value: false,
+        },
+      }),
+    );
+    expect(enableLpf.checked).toBe(false);
+  });
+
+  test("lpf-frequency should be updated when user change lpf-frequency-input", () => {
+    const lpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
+    const lpfFrequencyInput = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-lpfFrequency")
+    );
+    lpfFrequencyInput.value = lpfFrequency.toString();
+    lpfFrequencyInput.dispatchEvent(new Event(EventType.INPUT));
+    expect(playerSettingsService.lpfFrequency).toBeCloseTo(lpfFrequency);
+  });
+  test("lpf-frequency-input should be updated when recieving update-lpf-frequency event", () => {
+    const lpfFrequency = getRandomFloat(0, audioBuffer.sampleRate / 2);
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_LPF_FREQUENCY, {
+        detail: {
+          value: lpfFrequency,
+        },
+      }),
+    );
+    const lpfFrequencyInput = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-lpfFrequency")
+    );
+    expect(Number(lpfFrequencyInput.value)).toBeCloseTo(lpfFrequency);
+  });
+
+  test("match-filter-frequency-to-spectrogram should be updated when user change match-filter-frequency-to-spectrogram-input", () => {
+    const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-matchFilterFrequencyToSpectrogram")
+    );
+    matchFilterFrequencyToSpectrogram.checked = true;
+    matchFilterFrequencyToSpectrogram.dispatchEvent(new Event(EventType.CHANGE));
+    expect(playerSettingsService.matchFilterFrequencyToSpectrogram).toBe(true);
+
+    matchFilterFrequencyToSpectrogram.checked = false;
+    matchFilterFrequencyToSpectrogram.dispatchEvent(new Event(EventType.CHANGE));
+    expect(playerSettingsService.matchFilterFrequencyToSpectrogram).toBe(false);
+  });
+  test("match-filter-frequency-to-spectrogram should be updated when recieving update-match-filter-frequency-to-spectrogram event", () => {
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM, {
+        detail: {
+          value: true,
+        },
+      }),
+    );
+    const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
+      document.querySelector(".js-playerSetting-matchFilterFrequencyToSpectrogram")
+    );
+    expect(matchFilterFrequencyToSpectrogram.checked).toBe(true);
+
+    playerSettingsService.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM, {
+        detail: {
+          value: false,
+        },
+      }),
+    );
+    expect(matchFilterFrequencyToSpectrogram.checked).toBe(false);
+  });
+});

--- a/src/webview/components/playerSettings/playerSettingsComponent.test.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.test.ts
@@ -2,7 +2,6 @@ import { createAudioContext, getRandomFloat } from "../../../__mocks__/helper";
 import { EventType } from "../../events";
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
-import PlayerService from "../../services/playerService";
 import PlayerSettingsService from "../../services/playerSettingsService";
 import PlayerSettingsComponent from "./playerSettingsComponent";
 
@@ -51,14 +50,8 @@ describe("playerSettingsComponent", () => {
       pd,
       audioBuffer,
     );
-    const playerService = new PlayerService(
-      audioContext,
-      audioBuffer,
-      playerSettingsService,
-    );
     playerSettingsComponent = new PlayerSettingsComponent(
       "#playerSettings",
-      playerService,
       playerSettingsService,
       analyzeService,
       analyzeSettingsService,

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -46,36 +46,6 @@ export default class PlayerSettingsComponent extends Component {
   private initPlayerSettingUI() {
     const settings = this._playerSettingsService;
 
-    // init match filter frequency checkbox
-    const matchFilterFrequencyToSpectrogramInput =
-      this._componentRoot.querySelector(
-        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
-      ) as HTMLInputElement;
-    matchFilterFrequencyToSpectrogramInput.checked =
-      settings.matchFilterFrequencyToSpectrogram;
-    this._addEventlistener(
-      matchFilterFrequencyToSpectrogramInput,
-      EventType.CHANGE,
-      () => {
-        hpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
-        lpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
-        hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
-        lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
-
-        settings.matchFilterFrequencyToSpectrogram =
-          matchFilterFrequencyToSpectrogramInput.checked;
-        settings.hpfFrequency = Number(hpfFrequencyInput.value);
-        settings.lpfFrequency = Number(lpfFrequencyInput.value);
-      },
-    );
-    this._addEventlistener(
-      settings,
-      EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
-      (e: CustomEventInit) => {
-        matchFilterFrequencyToSpectrogramInput.checked = e.detail.value;
-      },
-    );
-
     // init enable high-pass filter checkbox
     const enableHpfInput = this._componentRoot.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
     enableHpfInput.checked = settings.enableHpf;
@@ -129,6 +99,36 @@ export default class PlayerSettingsComponent extends Component {
       EventType.PS_UPDATE_LPF_FREQUENCY,
       (e: CustomEventInit) => {
         lpfFrequencyInput.value = `${e.detail.value}`;
+      },
+    );
+
+    // init match filter frequency checkbox
+    const matchFilterFrequencyToSpectrogramInput =
+      this._componentRoot.querySelector(
+        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
+      ) as HTMLInputElement;
+    matchFilterFrequencyToSpectrogramInput.checked =
+      settings.matchFilterFrequencyToSpectrogram;
+    this._addEventlistener(
+      matchFilterFrequencyToSpectrogramInput,
+      EventType.CHANGE,
+      () => {
+        hpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
+        lpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
+        hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
+        lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
+
+        settings.matchFilterFrequencyToSpectrogram =
+          matchFilterFrequencyToSpectrogramInput.checked;
+        settings.hpfFrequency = Number(hpfFrequencyInput.value);
+        settings.lpfFrequency = Number(lpfFrequencyInput.value);
+      },
+    );
+    this._addEventlistener(
+      settings,
+      EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
+      (e: CustomEventInit) => {
+        matchFilterFrequencyToSpectrogramInput.checked = e.detail.value;
       },
     );
 

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -52,21 +52,29 @@ export default class PlayerSettingsComponent extends Component {
 
     // init match filter frequency checkbox
     const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
-      this._componentRoot.querySelector(".js-playerSetting-matchFilterFrequencyToSpectrogram")
+      this._componentRoot.querySelector(
+        ".js-playerSetting-matchFilterFrequencyToSpectrogram",
+      )
     );
-    matchFilterFrequencyToSpectrogram.checked = settings.matchFilterFrequencyToSpectrogram;
-    this._addEventlistener(matchFilterFrequencyToSpectrogram, EventType.CHANGE, () => {
-      hpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
-      lpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
-      hpfFrequency.value = String(this._analyzeSettingService.minFrequency);
-      lpfFrequency.value = String(this._analyzeSettingService.maxFrequency);
+    matchFilterFrequencyToSpectrogram.checked =
+      settings.matchFilterFrequencyToSpectrogram;
+    this._addEventlistener(
+      matchFilterFrequencyToSpectrogram,
+      EventType.CHANGE,
+      () => {
+        hpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
+        lpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
+        hpfFrequency.value = String(this._analyzeSettingService.minFrequency);
+        lpfFrequency.value = String(this._analyzeSettingService.maxFrequency);
 
-      settings.matchFilterFrequencyToSpectrogram = matchFilterFrequencyToSpectrogram.checked;
-      settings.hpfFrequency = Number(hpfFrequency.value);
-      settings.lpfFrequency = Number(lpfFrequency.value);
+        settings.matchFilterFrequencyToSpectrogram =
+          matchFilterFrequencyToSpectrogram.checked;
+        settings.hpfFrequency = Number(hpfFrequency.value);
+        settings.lpfFrequency = Number(lpfFrequency.value);
 
-      this.applyFilters();
-    });
+        this.applyFilters();
+      },
+    );
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
@@ -137,34 +145,29 @@ export default class PlayerSettingsComponent extends Component {
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_LPF_FREQUENCY,
-      (e: CustomEventInit) => {        
+      (e: CustomEventInit) => {
         lpfFrequency.value = `${e.detail.value}`;
         this.applyFilters();
       },
     );
 
-    this._addEventlistener(
-      this._analyzeService,
-      EventType.ANALYZE,
-      () => {
-        if (matchFilterFrequencyToSpectrogram.checked){
-          hpfFrequency.value = `${this._analyzeSettingService.minFrequency}`;
-          settings.hpfFrequency = Number(hpfFrequency.value);
+    this._addEventlistener(this._analyzeService, EventType.ANALYZE, () => {
+      if (matchFilterFrequencyToSpectrogram.checked) {
+        hpfFrequency.value = `${this._analyzeSettingService.minFrequency}`;
+        settings.hpfFrequency = Number(hpfFrequency.value);
 
-          lpfFrequency.value = `${this._analyzeSettingService.maxFrequency}`;
-          settings.lpfFrequency = Number(lpfFrequency.value);
+        lpfFrequency.value = `${this._analyzeSettingService.maxFrequency}`;
+        settings.lpfFrequency = Number(lpfFrequency.value);
 
-          this.applyFilters();
-        }
-      },
-    );
+        this.applyFilters();
+      }
+    });
   }
-  
-  private applyFilters()
-  {
+
+  private applyFilters() {
     if (this._playerService.isPlaying) {
       this._playerService.pause();
       this._playerService.play();
-    }    
+    }
   }
 }

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -63,8 +63,8 @@ export default class PlayerSettingsComponent extends Component {
       () => {
         hpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
         lpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
-        hpfFrequency.value = String(this._analyzeSettingService.minFrequency);
-        lpfFrequency.value = String(this._analyzeSettingService.maxFrequency);
+        hpfFrequency.value = `${this._analyzeSettingService.minFrequency}`;
+        lpfFrequency.value = `${this._analyzeSettingService.maxFrequency}`;
 
         settings.matchFilterFrequencyToSpectrogram =
           matchFilterFrequencyToSpectrogram.checked;

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -51,26 +51,25 @@ export default class PlayerSettingsComponent extends Component {
     const settings = this._playerSettingsService;
 
     // init match filter frequency checkbox
-    const matchFilterFrequencyToSpectrogram =
+    const matchFilterFrequencyToSpectrogramInput =
       this._componentRoot.querySelector(
         ".js-playerSetting-matchFilterFrequencyToSpectrogram",
       ) as HTMLInputElement;
-    matchFilterFrequencyToSpectrogram.checked =
+    matchFilterFrequencyToSpectrogramInput.checked =
       settings.matchFilterFrequencyToSpectrogram;
     this._addEventlistener(
-      matchFilterFrequencyToSpectrogram,
+      matchFilterFrequencyToSpectrogramInput,
       EventType.CHANGE,
       () => {
-        hpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
-        lpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
-        hpfFrequency.value = `${this._analyzeSettingService.minFrequency}`;
-        lpfFrequency.value = `${this._analyzeSettingService.maxFrequency}`;
+        hpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
+        lpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
+        hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
+        lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
 
         settings.matchFilterFrequencyToSpectrogram =
-          matchFilterFrequencyToSpectrogram.checked;
-        settings.hpfFrequency = Number(hpfFrequency.value);
-        settings.lpfFrequency = Number(lpfFrequency.value);
-
+          matchFilterFrequencyToSpectrogramInput.checked;
+        settings.hpfFrequency = Number(hpfFrequencyInput.value);
+        settings.lpfFrequency = Number(lpfFrequencyInput.value);
         this.applyFilters();
       },
     );
@@ -78,78 +77,77 @@ export default class PlayerSettingsComponent extends Component {
       settings,
       EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
       (e: CustomEventInit) => {
-        matchFilterFrequencyToSpectrogram.checked = e.detail.value;
+        matchFilterFrequencyToSpectrogramInput.checked = e.detail.value;
       },
     );
 
     // init enable high-pass filter checkbox
-    const enableHpf = this._componentRoot.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
-    enableHpf.checked = settings.enableHpf;
-    this._addEventlistener(enableHpf, EventType.CHANGE, () => {
-      settings.enableHpf = enableHpf.checked;
+    const enableHpfInput = this._componentRoot.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
+    enableHpfInput.checked = settings.enableHpf;
+    this._addEventlistener(enableHpfInput, EventType.CHANGE, () => {
+      settings.enableHpf = enableHpfInput.checked;
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_ENABLE_HPF,
       (e: CustomEventInit) => {
-        enableHpf.checked = e.detail.value;
+        enableHpfInput.checked = e.detail.value;
         this.applyFilters();
       },
     );
 
     // init high-pass filter frequency input
-    const hpfFrequency = this._componentRoot.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
-    hpfFrequency.value = `${settings.hpfFrequency}`;
-    this._addEventlistener(hpfFrequency, EventType.INPUT, () => {
-      settings.hpfFrequency = Number(hpfFrequency.value);
+    const hpfFrequencyInput = this._componentRoot.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
+    hpfFrequencyInput.value = `${settings.hpfFrequency}`;
+    this._addEventlistener(hpfFrequencyInput, EventType.INPUT, () => {
+      settings.hpfFrequency = Number(hpfFrequencyInput.value);
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_HPF_FREQUENCY,
       (e: CustomEventInit) => {
-        hpfFrequency.value = `${e.detail.value}`;
+        hpfFrequencyInput.value = `${e.detail.value}`;
         this.applyFilters();
       },
     );
 
     // init enable low-pass filter checkbox
-    const enableLpf = this._componentRoot.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
-    enableLpf.checked = settings.enableLpf;
-    this._addEventlistener(enableLpf, EventType.CHANGE, () => {
-      settings.enableLpf = enableLpf.checked;
+    const enableLpfInput = this._componentRoot.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
+    enableLpfInput.checked = settings.enableLpf;
+    this._addEventlistener(enableLpfInput, EventType.CHANGE, () => {
+      settings.enableLpf = enableLpfInput.checked;
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_ENABLE_LPF,
       (e: CustomEventInit) => {
-        enableLpf.checked = e.detail.value;
+        enableLpfInput.checked = e.detail.value;
         this.applyFilters();
       },
     );
 
     // init low-pass filter frequency input
-    const lpfFrequency = this._componentRoot.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
-    lpfFrequency.value = `${settings.lpfFrequency}`;
-    this._addEventlistener(lpfFrequency, EventType.INPUT, () => {
-      settings.lpfFrequency = Number(lpfFrequency.value);
+    const lpfFrequencyInput = this._componentRoot.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
+    lpfFrequencyInput.value = `${settings.lpfFrequency}`;
+    this._addEventlistener(lpfFrequencyInput, EventType.INPUT, () => {
+      settings.lpfFrequency = Number(lpfFrequencyInput.value);
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_LPF_FREQUENCY,
       (e: CustomEventInit) => {
-        lpfFrequency.value = `${e.detail.value}`;
+        lpfFrequencyInput.value = `${e.detail.value}`;
         this.applyFilters();
       },
     );
 
     this._addEventlistener(this._analyzeService, EventType.ANALYZE, () => {
-      if (matchFilterFrequencyToSpectrogram.checked) {
-        hpfFrequency.value = `${this._analyzeSettingService.minFrequency}`;
-        settings.hpfFrequency = Number(hpfFrequency.value);
+      if (matchFilterFrequencyToSpectrogramInput.checked) {
+        hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
+        settings.hpfFrequency = Number(hpfFrequencyInput.value);
 
-        lpfFrequency.value = `${this._analyzeSettingService.maxFrequency}`;
-        settings.lpfFrequency = Number(lpfFrequency.value);
-
+        lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
+        settings.lpfFrequency = Number(lpfFrequencyInput.value);
         this.applyFilters();
       }
     });

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -82,13 +82,13 @@ export default class PlayerSettingsComponent extends Component {
     enableHpf.checked = settings.enableHpf;
     this._addEventlistener(enableHpf, EventType.CHANGE, () => {
       settings.enableHpf = enableHpf.checked;
-      this.applyFilters();
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_ENABLE_HPF,
       (e: CustomEventInit) => {
         enableHpf.checked = e.detail.value;
+        this.applyFilters();
       },
     );
 
@@ -99,13 +99,13 @@ export default class PlayerSettingsComponent extends Component {
     hpfFrequency.value = `${settings.hpfFrequency}`;
     this._addEventlistener(hpfFrequency, EventType.INPUT, () => {
       settings.hpfFrequency = Number(hpfFrequency.value);
-      this.applyFilters();
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_HPF_FREQUENCY,
       (e: CustomEventInit) => {
         hpfFrequency.value = `${e.detail.value}`;
+        this.applyFilters();
       },
     );
 
@@ -116,13 +116,13 @@ export default class PlayerSettingsComponent extends Component {
     enableLpf.checked = settings.enableLpf;
     this._addEventlistener(enableLpf, EventType.CHANGE, () => {
       settings.enableLpf = enableLpf.checked;
-      this.applyFilters();
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_ENABLE_LPF,
       (e: CustomEventInit) => {
         enableLpf.checked = e.detail.value;
+        this.applyFilters();
       },
     );
 
@@ -133,13 +133,13 @@ export default class PlayerSettingsComponent extends Component {
     lpfFrequency.value = `${settings.lpfFrequency}`;
     this._addEventlistener(lpfFrequency, EventType.INPUT, () => {
       settings.lpfFrequency = Number(lpfFrequency.value);
-      this.applyFilters();
     });
     this._addEventlistener(
       settings,
       EventType.PS_UPDATE_LPF_FREQUENCY,
       (e: CustomEventInit) => {        
         lpfFrequency.value = `${e.detail.value}`;
+        this.applyFilters();
       },
     );
 
@@ -162,7 +162,7 @@ export default class PlayerSettingsComponent extends Component {
   
   private applyFilters()
   {
-    if (this._playerService.isPlaying && (this._playerSettingsService.enableHpf || this._playerSettingsService.enableLpf)) {
+    if (this._playerService.isPlaying) {
       this._playerService.pause();
       this._playerService.play();
     }    

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -51,11 +51,10 @@ export default class PlayerSettingsComponent extends Component {
     const settings = this._playerSettingsService;
 
     // init match filter frequency checkbox
-    const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
+    const matchFilterFrequencyToSpectrogram =
       this._componentRoot.querySelector(
         ".js-playerSetting-matchFilterFrequencyToSpectrogram",
-      )
-    );
+      ) as HTMLInputElement;
     matchFilterFrequencyToSpectrogram.checked =
       settings.matchFilterFrequencyToSpectrogram;
     this._addEventlistener(
@@ -84,9 +83,7 @@ export default class PlayerSettingsComponent extends Component {
     );
 
     // init enable high-pass filter checkbox
-    const enableHpf = <HTMLInputElement>(
-      this._componentRoot.querySelector(".js-playerSetting-enableHpf")
-    );
+    const enableHpf = this._componentRoot.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
     enableHpf.checked = settings.enableHpf;
     this._addEventlistener(enableHpf, EventType.CHANGE, () => {
       settings.enableHpf = enableHpf.checked;
@@ -101,9 +98,7 @@ export default class PlayerSettingsComponent extends Component {
     );
 
     // init high-pass filter frequency input
-    const hpfFrequency = <HTMLInputElement>(
-      this._componentRoot.querySelector(".js-playerSetting-hpfFrequency")
-    );
+    const hpfFrequency = this._componentRoot.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
     hpfFrequency.value = `${settings.hpfFrequency}`;
     this._addEventlistener(hpfFrequency, EventType.INPUT, () => {
       settings.hpfFrequency = Number(hpfFrequency.value);
@@ -118,9 +113,7 @@ export default class PlayerSettingsComponent extends Component {
     );
 
     // init enable low-pass filter checkbox
-    const enableLpf = <HTMLInputElement>(
-      this._componentRoot.querySelector(".js-playerSetting-enableLpf")
-    );
+    const enableLpf = this._componentRoot.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
     enableLpf.checked = settings.enableLpf;
     this._addEventlistener(enableLpf, EventType.CHANGE, () => {
       settings.enableLpf = enableLpf.checked;
@@ -135,9 +128,7 @@ export default class PlayerSettingsComponent extends Component {
     );
 
     // init low-pass filter frequency input
-    const lpfFrequency = <HTMLInputElement>(
-      this._componentRoot.querySelector(".js-playerSetting-lpfFrequency")
-    );
+    const lpfFrequency = this._componentRoot.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
     lpfFrequency.value = `${settings.lpfFrequency}`;
     this._addEventlistener(lpfFrequency, EventType.INPUT, () => {
       settings.lpfFrequency = Number(lpfFrequency.value);

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -109,6 +109,8 @@ export default class PlayerSettingsComponent extends Component {
       ) as HTMLInputElement;
     matchFilterFrequencyToSpectrogramInput.checked =
       settings.matchFilterFrequencyToSpectrogram;
+    hpfFrequencyInput.readOnly = settings.matchFilterFrequencyToSpectrogram;
+    lpfFrequencyInput.readOnly = settings.matchFilterFrequencyToSpectrogram;
     this._addEventlistener(
       matchFilterFrequencyToSpectrogramInput,
       EventType.CHANGE,

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -67,7 +67,7 @@ export default class PlayerSettingsComponent extends Component {
       ".js-playerSetting-hpfFrequency",
     ) as HTMLInputElement;
     hpfFrequencyInput.value = `${settings.hpfFrequency}`;
-    this._addEventlistener(hpfFrequencyInput, EventType.INPUT, () => {
+    this._addEventlistener(hpfFrequencyInput, EventType.CHANGE, () => {
       settings.hpfFrequency = Number(hpfFrequencyInput.value);
     });
     this._addEventlistener(
@@ -99,7 +99,7 @@ export default class PlayerSettingsComponent extends Component {
       ".js-playerSetting-lpfFrequency",
     ) as HTMLInputElement;
     lpfFrequencyInput.value = `${settings.lpfFrequency}`;
-    this._addEventlistener(lpfFrequencyInput, EventType.INPUT, () => {
+    this._addEventlistener(lpfFrequencyInput, EventType.CHANGE, () => {
       settings.lpfFrequency = Number(lpfFrequencyInput.value);
     });
     this._addEventlistener(

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -35,7 +35,7 @@ export default class PlayerSettingsComponent extends Component {
           <input class="playerSetting__input js-playerSetting-lpfFrequency" type="number" min="10" max="100000" step="10"> Hz
       </div>      
       <div>
-          <input class="playerSetting__input js-playerSetting-matchFilterFrequencyToSpectrogram" type="checkbox"> match to spectrogram frequency range
+          <input class="playerSetting__input js-playerSetting-matchFilterFrequencyToSpectrogram" type="checkbox">match to spectrogram frequency range
       </div>
     </div>
     `;
@@ -73,7 +73,7 @@ export default class PlayerSettingsComponent extends Component {
         hpfFrequencyInput.value = `${e.detail.value}`;
       },
     );
-
+    
     // init enable low-pass filter checkbox
     const enableLpfInput = this._componentRoot.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
     enableLpfInput.checked = settings.enableLpf;
@@ -118,13 +118,13 @@ export default class PlayerSettingsComponent extends Component {
         hpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
         lpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
         settings.matchFilterFrequencyToSpectrogram =
-          matchFilterFrequencyToSpectrogramInput.checked;
+        matchFilterFrequencyToSpectrogramInput.checked;
         
         if (matchFilterFrequencyToSpectrogramInput.checked) {
           hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
           lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
-        settings.hpfFrequency = Number(hpfFrequencyInput.value);
-        settings.lpfFrequency = Number(lpfFrequencyInput.value);
+          settings.hpfFrequency = Number(hpfFrequencyInput.value);
+          settings.lpfFrequency = Number(lpfFrequencyInput.value);
         }
       },
     );

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -1,0 +1,170 @@
+import "./playerSettingsComponent.css";
+import Component from "../../component";
+import { EventType } from "../../events";
+import PlayerService from "../../services/playerService";
+import PlayerSettingsService from "../../services/playerSettingsService";
+import AnalyzeService from "../../services/analyzeService";
+import AnalyzeSettingsService from "../../services/analyzeSettingsService";
+
+export default class PlayerSettingsComponent extends Component {
+  private _componentRoot: HTMLElement;
+  private _playerService: PlayerService;
+  private _playerSettingsService: PlayerSettingsService;
+  private _analyzeService: AnalyzeService;
+  private _analyzeSettingService: AnalyzeSettingsService;
+
+  constructor(
+    componentRootSelector: string,
+    playerService: PlayerService,
+    playerSettingsService: PlayerSettingsService,
+    analyzeService: AnalyzeService,
+    analyzeSettingService: AnalyzeSettingsService,
+  ) {
+    super();
+    this._componentRoot = document.querySelector(componentRootSelector);
+    this._playerService = playerService;
+    this._playerSettingsService = playerSettingsService;
+    this._analyzeService = analyzeService;
+    this._analyzeSettingService = analyzeSettingService;
+
+    this._componentRoot.innerHTML = `
+    <div class="playerSetting">
+      <h3>Filters</h3>
+      <div>
+          <input class="playerSetting__input js-playerSetting-enableHpf" type="checkbox">high-pass:  
+          <input class="playerSetting__input js-playerSetting-hpfFrequency" type="number" min="10" max="100000" step="10"> Hz
+      </div>
+      <div>
+          <input class="playerSetting__input js-playerSetting-enableLpf" type="checkbox">low-pass:  
+          <input class="playerSetting__input js-playerSetting-lpfFrequency" type="number" min="10" max="100000" step="10"> Hz
+      </div>      
+      <div>
+          <input class="playerSetting__input js-playerSetting-matchFilterFrequencyToSpectrogram" type="checkbox"> match to spectrogram frequency range
+      </div>
+    </div>
+    `;
+
+    this.initPlayerSettingUI();
+  }
+
+  private initPlayerSettingUI() {
+    const settings = this._playerSettingsService;
+
+    // init match filter frequency checkbox
+    const matchFilterFrequencyToSpectrogram = <HTMLInputElement>(
+      this._componentRoot.querySelector(".js-playerSetting-matchFilterFrequencyToSpectrogram")
+    );
+    matchFilterFrequencyToSpectrogram.checked = settings.matchFilterFrequencyToSpectrogram;
+    this._addEventlistener(matchFilterFrequencyToSpectrogram, EventType.CHANGE, () => {
+      hpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
+      lpfFrequency.readOnly = matchFilterFrequencyToSpectrogram.checked;
+      hpfFrequency.value = String(this._analyzeSettingService.minFrequency);
+      lpfFrequency.value = String(this._analyzeSettingService.maxFrequency);
+
+      settings.matchFilterFrequencyToSpectrogram = matchFilterFrequencyToSpectrogram.checked;
+      settings.hpfFrequency = Number(hpfFrequency.value);
+      settings.lpfFrequency = Number(lpfFrequency.value);
+
+      this.applyFilters();
+    });
+    this._addEventlistener(
+      settings,
+      EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
+      (e: CustomEventInit) => {
+        matchFilterFrequencyToSpectrogram.checked = e.detail.value;
+      },
+    );
+
+    // init enable high-pass filter checkbox
+    const enableHpf = <HTMLInputElement>(
+      this._componentRoot.querySelector(".js-playerSetting-enableHpf")
+    );
+    enableHpf.checked = settings.enableHpf;
+    this._addEventlistener(enableHpf, EventType.CHANGE, () => {
+      settings.enableHpf = enableHpf.checked;
+      this.applyFilters();
+    });
+    this._addEventlistener(
+      settings,
+      EventType.PS_UPDATE_ENABLE_HPF,
+      (e: CustomEventInit) => {
+        enableHpf.checked = e.detail.value;
+      },
+    );
+
+    // init high-pass filter frequency input
+    const hpfFrequency = <HTMLInputElement>(
+      this._componentRoot.querySelector(".js-playerSetting-hpfFrequency")
+    );
+    hpfFrequency.value = `${settings.hpfFrequency}`;
+    this._addEventlistener(hpfFrequency, EventType.INPUT, () => {
+      settings.hpfFrequency = Number(hpfFrequency.value);
+      this.applyFilters();
+    });
+    this._addEventlistener(
+      settings,
+      EventType.PS_UPDATE_HPF_FREQUENCY,
+      (e: CustomEventInit) => {
+        hpfFrequency.value = `${e.detail.value}`;
+      },
+    );
+
+    // init enable low-pass filter checkbox
+    const enableLpf = <HTMLInputElement>(
+      this._componentRoot.querySelector(".js-playerSetting-enableLpf")
+    );
+    enableLpf.checked = settings.enableLpf;
+    this._addEventlistener(enableLpf, EventType.CHANGE, () => {
+      settings.enableLpf = enableLpf.checked;
+      this.applyFilters();
+    });
+    this._addEventlistener(
+      settings,
+      EventType.PS_UPDATE_ENABLE_LPF,
+      (e: CustomEventInit) => {
+        enableLpf.checked = e.detail.value;
+      },
+    );
+
+    // init low-pass filter frequency input
+    const lpfFrequency = <HTMLInputElement>(
+      this._componentRoot.querySelector(".js-playerSetting-lpfFrequency")
+    );
+    lpfFrequency.value = `${settings.lpfFrequency}`;
+    this._addEventlistener(lpfFrequency, EventType.INPUT, () => {
+      settings.lpfFrequency = Number(lpfFrequency.value);
+      this.applyFilters();
+    });
+    this._addEventlistener(
+      settings,
+      EventType.PS_UPDATE_LPF_FREQUENCY,
+      (e: CustomEventInit) => {        
+        lpfFrequency.value = `${e.detail.value}`;
+      },
+    );
+
+    this._addEventlistener(
+      this._analyzeService,
+      EventType.ANALYZE,
+      () => {
+        if (matchFilterFrequencyToSpectrogram.checked){
+          hpfFrequency.value = `${this._analyzeSettingService.minFrequency}`;
+          settings.hpfFrequency = Number(hpfFrequency.value);
+
+          lpfFrequency.value = `${this._analyzeSettingService.maxFrequency}`;
+          settings.lpfFrequency = Number(lpfFrequency.value);
+
+          this.applyFilters();
+        }
+      },
+    );
+  }
+  
+  private applyFilters()
+  {
+    if (this._playerService.isPlaying) {
+      this._playerService.pause();
+      this._playerService.play();
+    }    
+  }
+}

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -1,28 +1,24 @@
 import "./playerSettingsComponent.css";
 import Component from "../../component";
 import { EventType } from "../../events";
-import PlayerService from "../../services/playerService";
 import PlayerSettingsService from "../../services/playerSettingsService";
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
 
 export default class PlayerSettingsComponent extends Component {
   private _componentRoot: HTMLElement;
-  private _playerService: PlayerService;
   private _playerSettingsService: PlayerSettingsService;
   private _analyzeService: AnalyzeService;
   private _analyzeSettingService: AnalyzeSettingsService;
 
   constructor(
     componentRootSelector: string,
-    playerService: PlayerService,
     playerSettingsService: PlayerSettingsService,
     analyzeService: AnalyzeService,
     analyzeSettingService: AnalyzeSettingsService,
   ) {
     super();
     this._componentRoot = document.querySelector(componentRootSelector);
-    this._playerService = playerService;
     this._playerSettingsService = playerSettingsService;
     this._analyzeService = analyzeService;
     this._analyzeSettingService = analyzeSettingService;
@@ -70,7 +66,6 @@ export default class PlayerSettingsComponent extends Component {
           matchFilterFrequencyToSpectrogramInput.checked;
         settings.hpfFrequency = Number(hpfFrequencyInput.value);
         settings.lpfFrequency = Number(lpfFrequencyInput.value);
-        this.applyFilters();
       },
     );
     this._addEventlistener(
@@ -92,7 +87,6 @@ export default class PlayerSettingsComponent extends Component {
       EventType.PS_UPDATE_ENABLE_HPF,
       (e: CustomEventInit) => {
         enableHpfInput.checked = e.detail.value;
-        this.applyFilters();
       },
     );
 
@@ -107,7 +101,6 @@ export default class PlayerSettingsComponent extends Component {
       EventType.PS_UPDATE_HPF_FREQUENCY,
       (e: CustomEventInit) => {
         hpfFrequencyInput.value = `${e.detail.value}`;
-        this.applyFilters();
       },
     );
 
@@ -122,7 +115,6 @@ export default class PlayerSettingsComponent extends Component {
       EventType.PS_UPDATE_ENABLE_LPF,
       (e: CustomEventInit) => {
         enableLpfInput.checked = e.detail.value;
-        this.applyFilters();
       },
     );
 
@@ -137,7 +129,6 @@ export default class PlayerSettingsComponent extends Component {
       EventType.PS_UPDATE_LPF_FREQUENCY,
       (e: CustomEventInit) => {
         lpfFrequencyInput.value = `${e.detail.value}`;
-        this.applyFilters();
       },
     );
 
@@ -148,15 +139,7 @@ export default class PlayerSettingsComponent extends Component {
 
         lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
         settings.lpfFrequency = Number(lpfFrequencyInput.value);
-        this.applyFilters();
       }
     });
-  }
-
-  private applyFilters() {
-    if (this._playerService.isPlaying) {
-      this._playerService.pause();
-      this._playerService.play();
-    }
   }
 }

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -47,7 +47,9 @@ export default class PlayerSettingsComponent extends Component {
     const settings = this._playerSettingsService;
 
     // init enable high-pass filter checkbox
-    const enableHpfInput = this._componentRoot.querySelector(".js-playerSetting-enableHpf") as HTMLInputElement;
+    const enableHpfInput = this._componentRoot.querySelector(
+      ".js-playerSetting-enableHpf",
+    ) as HTMLInputElement;
     enableHpfInput.checked = settings.enableHpf;
     this._addEventlistener(enableHpfInput, EventType.CHANGE, () => {
       settings.enableHpf = enableHpfInput.checked;
@@ -61,7 +63,9 @@ export default class PlayerSettingsComponent extends Component {
     );
 
     // init high-pass filter frequency input
-    const hpfFrequencyInput = this._componentRoot.querySelector(".js-playerSetting-hpfFrequency") as HTMLInputElement;
+    const hpfFrequencyInput = this._componentRoot.querySelector(
+      ".js-playerSetting-hpfFrequency",
+    ) as HTMLInputElement;
     hpfFrequencyInput.value = `${settings.hpfFrequency}`;
     this._addEventlistener(hpfFrequencyInput, EventType.INPUT, () => {
       settings.hpfFrequency = Number(hpfFrequencyInput.value);
@@ -73,9 +77,11 @@ export default class PlayerSettingsComponent extends Component {
         hpfFrequencyInput.value = `${e.detail.value}`;
       },
     );
-    
+
     // init enable low-pass filter checkbox
-    const enableLpfInput = this._componentRoot.querySelector(".js-playerSetting-enableLpf") as HTMLInputElement;
+    const enableLpfInput = this._componentRoot.querySelector(
+      ".js-playerSetting-enableLpf",
+    ) as HTMLInputElement;
     enableLpfInput.checked = settings.enableLpf;
     this._addEventlistener(enableLpfInput, EventType.CHANGE, () => {
       settings.enableLpf = enableLpfInput.checked;
@@ -89,7 +95,9 @@ export default class PlayerSettingsComponent extends Component {
     );
 
     // init low-pass filter frequency input
-    const lpfFrequencyInput = this._componentRoot.querySelector(".js-playerSetting-lpfFrequency") as HTMLInputElement;
+    const lpfFrequencyInput = this._componentRoot.querySelector(
+      ".js-playerSetting-lpfFrequency",
+    ) as HTMLInputElement;
     lpfFrequencyInput.value = `${settings.lpfFrequency}`;
     this._addEventlistener(lpfFrequencyInput, EventType.INPUT, () => {
       settings.lpfFrequency = Number(lpfFrequencyInput.value);
@@ -115,11 +123,13 @@ export default class PlayerSettingsComponent extends Component {
       matchFilterFrequencyToSpectrogramInput,
       EventType.CHANGE,
       () => {
-        hpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
-        lpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
+        hpfFrequencyInput.readOnly =
+          matchFilterFrequencyToSpectrogramInput.checked;
+        lpfFrequencyInput.readOnly =
+          matchFilterFrequencyToSpectrogramInput.checked;
         settings.matchFilterFrequencyToSpectrogram =
-        matchFilterFrequencyToSpectrogramInput.checked;
-        
+          matchFilterFrequencyToSpectrogramInput.checked;
+
         if (matchFilterFrequencyToSpectrogramInput.checked) {
           hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
           lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -117,13 +117,15 @@ export default class PlayerSettingsComponent extends Component {
       () => {
         hpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
         lpfFrequencyInput.readOnly = matchFilterFrequencyToSpectrogramInput.checked;
-        hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
-        lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
-
         settings.matchFilterFrequencyToSpectrogram =
           matchFilterFrequencyToSpectrogramInput.checked;
+        
+        if (matchFilterFrequencyToSpectrogramInput.checked) {
+          hpfFrequencyInput.value = `${this._analyzeSettingService.minFrequency}`;
+          lpfFrequencyInput.value = `${this._analyzeSettingService.maxFrequency}`;
         settings.hpfFrequency = Number(hpfFrequencyInput.value);
         settings.lpfFrequency = Number(lpfFrequencyInput.value);
+        }
       },
     );
     this._addEventlistener(

--- a/src/webview/components/playerSettings/playerSettingsComponent.ts
+++ b/src/webview/components/playerSettings/playerSettingsComponent.ts
@@ -162,7 +162,7 @@ export default class PlayerSettingsComponent extends Component {
   
   private applyFilters()
   {
-    if (this._playerService.isPlaying) {
+    if (this._playerService.isPlaying && (this._playerSettingsService.enableHpf || this._playerSettingsService.enableLpf)) {
       this._playerService.pause();
       this._playerService.play();
     }    

--- a/src/webview/components/settingTab/settingTabComponent.css
+++ b/src/webview/components/settingTab/settingTabComponent.css
@@ -4,7 +4,7 @@
 
 .settingTab__menu {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
   gap: 0.5em;
   margin: 0.5em;
 }

--- a/src/webview/components/settingTab/settingTabComponent.test.ts
+++ b/src/webview/components/settingTab/settingTabComponent.test.ts
@@ -1,18 +1,24 @@
 import {
+  createAudioContext,
   MockAudioBuffer,
   postMessageFromWebview,
 } from "../../../__mocks__/helper";
-import { AnalyzeDefault } from "../../../config";
+import { AnalyzeDefault, PlayerDefault } from "../../../config";
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
+import PlayerService from "../../services/playerService";
+import PlayerSettingsService from "../../services/playerSettingsService";
 import SettingTab from "./settingTabComponent";
 
 describe("settingTabComponent", () => {
+  let playerService: PlayerService;
+  let playerSettingService: PlayerSettingsService;
   let analyzeService: AnalyzeService;
   let analyzeSettingsService: AnalyzeSettingsService;
   let settingTabComponent: SettingTab;
   beforeAll(() => {
     document.body.innerHTML = '<div id="settingTab"></div>';
+    const audioContext = createAudioContext(44100);
     const audioBuffer = new MockAudioBuffer(
       44100,
       1,
@@ -24,8 +30,13 @@ describe("settingTabComponent", () => {
       analyzeDefault,
       audioBuffer,
     );
+    const playerDefault = {} as PlayerDefault;
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(playerDefault);
+    playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
     settingTabComponent = new SettingTab(
       "#settingTab",
+      playerService,
+      playerSettingService,
       analyzeService,
       analyzeSettingsService,
       audioBuffer,
@@ -44,6 +55,17 @@ describe("settingTabComponent", () => {
     for (const content of contents) {
       expect((content as HTMLElement).style.display).toBe("none");
     }
+  });
+
+  test("click player-button should show player content", () => {
+    const playerButton = document.querySelector(
+      ".js-settingTabButton-player",
+    ) as HTMLButtonElement;
+    playerButton.click();
+    const playerContent = document.querySelector(
+      ".js-settingTabContent-player",
+    ) as HTMLElement;
+    expect(playerContent.style.display).toBe("block");
   });
 
   test("click analyze-button should show analyze content", () => {

--- a/src/webview/components/settingTab/settingTabComponent.test.ts
+++ b/src/webview/components/settingTab/settingTabComponent.test.ts
@@ -31,7 +31,7 @@ describe("settingTabComponent", () => {
       audioBuffer,
     );
     const playerDefault = {} as PlayerDefault;
-    playerSettingService = PlayerSettingsService.fromDefaultSetting(playerDefault);
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(playerDefault, audioBuffer);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
     settingTabComponent = new SettingTab(
       "#settingTab",

--- a/src/webview/components/settingTab/settingTabComponent.test.ts
+++ b/src/webview/components/settingTab/settingTabComponent.test.ts
@@ -31,8 +31,15 @@ describe("settingTabComponent", () => {
       audioBuffer,
     );
     const playerDefault = {} as PlayerDefault;
-    playerSettingService = PlayerSettingsService.fromDefaultSetting(playerDefault, audioBuffer);
-    playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(
+      playerDefault,
+      audioBuffer,
+    );
+    playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingService,
+    );
     settingTabComponent = new SettingTab(
       "#settingTab",
       playerService,

--- a/src/webview/components/settingTab/settingTabComponent.test.ts
+++ b/src/webview/components/settingTab/settingTabComponent.test.ts
@@ -1,24 +1,20 @@
 import {
-  createAudioContext,
   MockAudioBuffer,
   postMessageFromWebview,
 } from "../../../__mocks__/helper";
 import { AnalyzeDefault, PlayerDefault } from "../../../config";
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
-import PlayerService from "../../services/playerService";
 import PlayerSettingsService from "../../services/playerSettingsService";
 import SettingTab from "./settingTabComponent";
 
 describe("settingTabComponent", () => {
-  let playerService: PlayerService;
   let playerSettingService: PlayerSettingsService;
   let analyzeService: AnalyzeService;
   let analyzeSettingsService: AnalyzeSettingsService;
   let settingTabComponent: SettingTab;
   beforeAll(() => {
     document.body.innerHTML = '<div id="settingTab"></div>';
-    const audioContext = createAudioContext(44100);
     const audioBuffer = new MockAudioBuffer(
       44100,
       1,
@@ -35,14 +31,8 @@ describe("settingTabComponent", () => {
       playerDefault,
       audioBuffer,
     );
-    playerService = new PlayerService(
-      audioContext,
-      audioBuffer,
-      playerSettingService,
-    );
     settingTabComponent = new SettingTab(
       "#settingTab",
-      playerService,
       playerSettingService,
       analyzeService,
       analyzeSettingsService,

--- a/src/webview/components/settingTab/settingTabComponent.ts
+++ b/src/webview/components/settingTab/settingTabComponent.ts
@@ -1,6 +1,9 @@
 import "./settingTabComponent.css";
 import Component from "../../component";
 import { EventType } from "../../events";
+import PlayerService from "../../services/playerService";
+import PlayerSettingsService from "../../services/playerSettingsService";
+import PlayerSettingsComponent from "../playerSettings/playerSettingsComponent"; 
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
 import AnalyzeSettingsComponent from "../analyzeSettings/analyzeSettingsComponent";
@@ -12,6 +15,8 @@ export default class SettingTab extends Component {
 
   constructor(
     coponentRootSelector: string,
+    playerService: PlayerService,
+    playerSettingsService: PlayerSettingsService,
     analyzeService: AnalyzeService,
     analyzeSettingsService: AnalyzeSettingsService,
     audioBuffer: AudioBuffer,
@@ -26,10 +31,12 @@ export default class SettingTab extends Component {
         <div class="settingTab__menu">
           <div>Setting</div>
           <button class="settingTab__button settingTab__button--active js-settingTabButton-hide">hide</button>
+          <button class="settingTab__button js-settingTabButton-player">player</button>
           <button class="settingTab__button js-settingTabButton-analyze">analyze</button>
           <button class="settingTab__button js-settingTabButton-easyCut">easyCut</button>
         </div>
         <div class="settingTab__content">
+          <div class="js-settingTabContent-player"></div>
           <div class="js-settingTabContent-analyze"></div>
           <div class="js-settingTabContent-easyCut"></div>
         </div>
@@ -40,6 +47,13 @@ export default class SettingTab extends Component {
     this.hideAllContent();
 
     // create tab content
+    new PlayerSettingsComponent(
+      `${coponentRootSelector} .js-settingTabContent-player`,
+      playerService,
+      playerSettingsService,
+      analyzeService,
+      analyzeSettingsService
+    );
     new AnalyzeSettingsComponent(
       `${coponentRootSelector} .js-settingTabContent-analyze`,
       analyzeService,
@@ -60,6 +74,20 @@ export default class SettingTab extends Component {
       this.hideAllContent();
       this.resetActivebutton();
       hideTabButton.classList.add("settingTab__button--active");
+    });
+
+    // player tab event
+    const playerTabButton = this._componentRoot.querySelector(
+      ".js-settingTabButton-player",
+    ) as HTMLButtonElement;
+    this._addEventlistener(playerTabButton, EventType.CLICK, () => {
+      this.hideAllContent();
+      this.resetActivebutton();
+      const playerTabContent = this._componentRoot.querySelector(
+        ".js-settingTabContent-player",
+      ) as HTMLElement;
+      playerTabContent.style.display = "block";
+      playerTabButton.classList.add("settingTab__button--active");
     });
 
     // analyze tab event

--- a/src/webview/components/settingTab/settingTabComponent.ts
+++ b/src/webview/components/settingTab/settingTabComponent.ts
@@ -1,7 +1,6 @@
 import "./settingTabComponent.css";
 import Component from "../../component";
 import { EventType } from "../../events";
-import PlayerService from "../../services/playerService";
 import PlayerSettingsService from "../../services/playerSettingsService";
 import PlayerSettingsComponent from "../playerSettings/playerSettingsComponent";
 import AnalyzeService from "../../services/analyzeService";
@@ -15,7 +14,6 @@ export default class SettingTab extends Component {
 
   constructor(
     coponentRootSelector: string,
-    playerService: PlayerService,
     playerSettingsService: PlayerSettingsService,
     analyzeService: AnalyzeService,
     analyzeSettingsService: AnalyzeSettingsService,
@@ -49,7 +47,6 @@ export default class SettingTab extends Component {
     // create tab content
     new PlayerSettingsComponent(
       `${coponentRootSelector} .js-settingTabContent-player`,
-      playerService,
       playerSettingsService,
       analyzeService,
       analyzeSettingsService,

--- a/src/webview/components/settingTab/settingTabComponent.ts
+++ b/src/webview/components/settingTab/settingTabComponent.ts
@@ -3,7 +3,7 @@ import Component from "../../component";
 import { EventType } from "../../events";
 import PlayerService from "../../services/playerService";
 import PlayerSettingsService from "../../services/playerSettingsService";
-import PlayerSettingsComponent from "../playerSettings/playerSettingsComponent"; 
+import PlayerSettingsComponent from "../playerSettings/playerSettingsComponent";
 import AnalyzeService from "../../services/analyzeService";
 import AnalyzeSettingsService from "../../services/analyzeSettingsService";
 import AnalyzeSettingsComponent from "../analyzeSettings/analyzeSettingsComponent";
@@ -52,7 +52,7 @@ export default class SettingTab extends Component {
       playerService,
       playerSettingsService,
       analyzeService,
-      analyzeSettingsService
+      analyzeSettingsService,
     );
     new AnalyzeSettingsComponent(
       `${coponentRootSelector} .js-settingTabContent-analyze`,

--- a/src/webview/components/webview/webview.test.ts
+++ b/src/webview/components/webview/webview.test.ts
@@ -8,6 +8,7 @@ import {
   createAudioContext,
   wait,
 } from "../../../__mocks__/helper";
+import PlayerSettingsService from "../../services/playerSettingsService";
 
 describe("webview", () => {
   let webview: Webview;
@@ -61,6 +62,11 @@ describe("webview", () => {
             initialVolume: 1.0,
             enableSpacekeyPlay: true,
             enableSeekToPlay: true,
+            enableHpf: false,
+            hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+            enableLpf: false,
+            lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+            matchFilterFrequencyToSpectrogram: false,
           },
           analyzeDefault: {
             waveformVisible: undefined,
@@ -198,6 +204,11 @@ describe("webview error handling", () => {
             initialVolume: 1.0,
             enableSpacekeyPlay: true,
             enableSeekToPlay: true,
+            enableHpf: false,
+            hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+            enableLpf: false,
+            lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+            matchFilterFrequencyToSpectrogram: false,
           },
           analyzeDefault: {
             waveformVisible: undefined,

--- a/src/webview/components/webview/webview.ts
+++ b/src/webview/components/webview/webview.ts
@@ -156,6 +156,7 @@ export default class WebView extends Component {
     // init player
     const playerSettingsService = PlayerSettingsService.fromDefaultSetting(
       this._config.playerDefault,
+      audioBuffer
     );
     const playerService = new PlayerService(audioContext, audioBuffer, playerSettingsService);
     const playerComponent = new PlayerComponent(

--- a/src/webview/components/webview/webview.ts
+++ b/src/webview/components/webview/webview.ts
@@ -178,7 +178,6 @@ export default class WebView extends Component {
     );
     const settingTabComponent = new SettingTab(
       "#settingTab",
-      playerService,
       playerSettingsService,
       analyzeService,
       analyzeSettingsService,

--- a/src/webview/components/webview/webview.ts
+++ b/src/webview/components/webview/webview.ts
@@ -173,6 +173,8 @@ export default class WebView extends Component {
     );
     const settingTabComponent = new SettingTab(
       "#settingTab",
+      playerService,
+      playerSettingsService,
       analyzeService,
       analyzeSettingsService,
       audioBuffer,

--- a/src/webview/components/webview/webview.ts
+++ b/src/webview/components/webview/webview.ts
@@ -156,7 +156,7 @@ export default class WebView extends Component {
     // init player
     const playerSettingsService = PlayerSettingsService.fromDefaultSetting(
       this._config.playerDefault,
-      audioBuffer
+      audioBuffer,
     );
     const playerService = new PlayerService(
       audioContext,

--- a/src/webview/events.ts
+++ b/src/webview/events.ts
@@ -11,7 +11,8 @@ export class EventType {
   public static readonly PS_UPDATE_HPF_FREQUENCY = "update-hpf-frequency";
   public static readonly PS_UPDATE_ENABLE_LPF = "update-enable-lpf";
   public static readonly PS_UPDATE_LPF_FREQUENCY = "update-lpf-frequency";
-  public static readonly PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM = "update-match-filter-frequency-to-spectrogram";
+  public static readonly PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM =
+    "update-match-filter-frequency-to-spectrogram";
   // analyzer
   public static readonly ANALYZE = "analyze";
   // analyzeSettings

--- a/src/webview/events.ts
+++ b/src/webview/events.ts
@@ -6,6 +6,12 @@ export class EventType {
   // player
   public static readonly UPDATE_SEEKBAR = "update-seekbar";
   public static readonly UPDATE_IS_PLAYING = "update-is-playing";
+  // playerSettings
+  public static readonly PS_UPDATE_ENABLE_HPF = "update-enable-hpf";
+  public static readonly PS_UPDATE_HPF_FREQUENCY = "update-hpf-frequency";
+  public static readonly PS_UPDATE_ENABLE_LPF = "update-enable-lpf";
+  public static readonly PS_UPDATE_LPF_FREQUENCY = "update-lpf-frequency";
+  public static readonly PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM = "update-match-filter-frequency-to-spectrogram";
   // analyzer
   public static readonly ANALYZE = "analyze";
   // analyzeSettings

--- a/src/webview/services/playerService.test.ts
+++ b/src/webview/services/playerService.test.ts
@@ -11,8 +11,15 @@ describe("playerService", () => {
     const audioContext = createAudioContext(44100);
     const audioBuffer = audioContext.createBuffer(1, 44100 * 10, 44100);
     const pd = {} as PlayerDefault;
-    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
-    playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(
+      pd,
+      audioBuffer,
+    );
+    playerService = new PlayerService(
+      audioContext,
+      audioBuffer,
+      playerSettingService,
+    );
   });
 
   afterAll(() => {

--- a/src/webview/services/playerService.test.ts
+++ b/src/webview/services/playerService.test.ts
@@ -11,7 +11,7 @@ describe("playerService", () => {
     const audioContext = createAudioContext(44100);
     const audioBuffer = audioContext.createBuffer(1, 44100 * 10, 44100);
     const pd = {} as PlayerDefault;
-    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd, audioBuffer);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
   });
 

--- a/src/webview/services/playerService.test.ts
+++ b/src/webview/services/playerService.test.ts
@@ -1,6 +1,7 @@
 import { EventType } from "../events";
 import { createAudioContext, waitEventForAction } from "../../__mocks__/helper";
 import PlayerService from "./playerService";
+import { PlayerDefault } from "../../config";
 import PlayerSettingsService from "./playerSettingsService";
 
 describe("playerService", () => {
@@ -9,6 +10,8 @@ describe("playerService", () => {
   beforeAll(() => {
     const audioContext = createAudioContext(44100);
     const audioBuffer = audioContext.createBuffer(1, 44100 * 10, 44100);
+    const pd = {} as PlayerDefault;
+    playerSettingService = PlayerSettingsService.fromDefaultSetting(pd);
     playerService = new PlayerService(audioContext, audioBuffer, playerSettingService);
   });
 

--- a/src/webview/services/playerService.ts
+++ b/src/webview/services/playerService.ts
@@ -40,7 +40,11 @@ export default class PlayerService extends Service {
   private _seekbarValue: number = 0;
   private _animationFrameID: number = 0;
 
-  constructor(audioContext: AudioContext, audioBuffer: AudioBuffer, playerSettingsService: PlayerSettingsService) {
+  constructor(
+    audioContext: AudioContext,
+    audioBuffer: AudioBuffer,
+    playerSettingsService: PlayerSettingsService,
+  ) {
     super();
     this._audioContext = audioContext;
     this._audioBuffer = audioBuffer;
@@ -53,25 +57,25 @@ export default class PlayerService extends Service {
     // init high-pass filter
     this._hpfNode = this._audioContext.createBiquadFilter();
     this._hpfNode.type = "highpass";
-    this._hpfNode.Q.value = Math.SQRT1_2;   // butterworth
-    
+    this._hpfNode.Q.value = Math.SQRT1_2; // butterworth
+
     // init high-pass filter
     this._lpfNode = this._audioContext.createBiquadFilter();
     this._lpfNode.type = "lowpass";
-    this._lpfNode.Q.value = Math.SQRT1_2;   // butterworth
+    this._lpfNode.Q.value = Math.SQRT1_2; // butterworth
   }
 
-  public play() {    
+  public play() {
     // connect nodes
     let lastNode = this._gainNode;
-    
+
     this._lpfNode.disconnect();
     if (this._playerSettingsService.enableLpf) {
       this._lpfNode.frequency.value = this._playerSettingsService.lpfFrequency;
       this._lpfNode.connect(lastNode);
       lastNode = this._lpfNode;
-    } 
-    
+    }
+
     this._hpfNode.disconnect();
     if (this._playerSettingsService.enableHpf) {
       this._hpfNode.frequency.value = this._playerSettingsService.hpfFrequency;
@@ -85,13 +89,13 @@ export default class PlayerService extends Service {
     this._source = this._audioContext.createBufferSource();
     this._source.buffer = this._audioBuffer;
     this._source.connect(lastNode);
-    
+
     // play
     this._isPlaying = true;
     this._lastStartAcTime = this._audioContext.currentTime;
     this._source.start(this._audioContext.currentTime, this._currentSec);
 
-// update playing status
+    // update playing status
     this.dispatchEvent(
       new CustomEvent(EventType.UPDATE_IS_PLAYING, {
         detail: {
@@ -174,7 +178,7 @@ export default class PlayerService extends Service {
     );
 
     // restart from selected place
-    if (resumeRequired || this._playerSettingsService.enableSeekToPlay){
+    if (resumeRequired || this._playerSettingsService.enableSeekToPlay) {
       this.play();
     }
   }

--- a/src/webview/services/playerService.ts
+++ b/src/webview/services/playerService.ts
@@ -125,7 +125,7 @@ export default class PlayerService extends Service {
 
   // seekbar value is 0~100
   public onSeekbarInput(value: number) {
-    const resumeRequired: boolean = this._isPlaying;
+    const resumeRequired = this._isPlaying;
 
     if (this._isPlaying) {
       this.pause();

--- a/src/webview/services/playerService.ts
+++ b/src/webview/services/playerService.ts
@@ -71,10 +71,22 @@ export default class PlayerService extends Service {
         this.play();
       }
     };
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_HPF, applyFilters);
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_HPF_FREQUENCY, applyFilters);
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_LPF, applyFilters);
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_LPF_FREQUENCY, applyFilters);
+    this._playerSettingsService.addEventListener(
+      EventType.PS_UPDATE_ENABLE_HPF,
+      applyFilters,
+    );
+    this._playerSettingsService.addEventListener(
+      EventType.PS_UPDATE_HPF_FREQUENCY,
+      applyFilters,
+    );
+    this._playerSettingsService.addEventListener(
+      EventType.PS_UPDATE_ENABLE_LPF,
+      applyFilters,
+    );
+    this._playerSettingsService.addEventListener(
+      EventType.PS_UPDATE_LPF_FREQUENCY,
+      applyFilters,
+    );
   }
 
   public play() {

--- a/src/webview/services/playerService.ts
+++ b/src/webview/services/playerService.ts
@@ -63,6 +63,19 @@ export default class PlayerService extends Service {
     this._lpfNode = this._audioContext.createBiquadFilter();
     this._lpfNode.type = "lowpass";
     this._lpfNode.Q.value = Math.SQRT1_2; // butterworth
+
+    // play again if filter related setting is changed
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_HPF, this.applyFilters);
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_HPF_FREQUENCY, this.applyFilters);
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_LPF, this.applyFilters);
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_LPF_FREQUENCY, this.applyFilters);
+  }
+
+  private applyFilters() {
+    if(this.isPlaying){
+      this.pause();
+      this.play();
+    }
   }
 
   public play() {

--- a/src/webview/services/playerService.ts
+++ b/src/webview/services/playerService.ts
@@ -65,17 +65,16 @@ export default class PlayerService extends Service {
     this._lpfNode.Q.value = Math.SQRT1_2; // butterworth
 
     // play again if filter related setting is changed
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_HPF, this.applyFilters);
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_HPF_FREQUENCY, this.applyFilters);
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_LPF, this.applyFilters);
-    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_LPF_FREQUENCY, this.applyFilters);
-  }
-
-  private applyFilters() {
-    if(this.isPlaying){
-      this.pause();
-      this.play();
-    }
+    const applyFilters = () => {
+      if (this._isPlaying) {
+        this.pause();
+        this.play();
+      }
+    };
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_HPF, applyFilters);
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_HPF_FREQUENCY, applyFilters);
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_ENABLE_LPF, applyFilters);
+    this._playerSettingsService.addEventListener(EventType.PS_UPDATE_LPF_FREQUENCY, applyFilters);
   }
 
   public play() {

--- a/src/webview/services/playerSettingsService.test.ts
+++ b/src/webview/services/playerSettingsService.test.ts
@@ -1,5 +1,5 @@
 import { PlayerDefault } from "../../config";
-import PlayerSettingService from "./playerSettingsService";
+import PlayerSettingsService from "./playerSettingsService";
 
 describe("playerSettingsService", () => {
   let defaultSettings: PlayerDefault;
@@ -11,100 +11,100 @@ describe("playerSettingsService", () => {
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
       enableHpf: false,
-      hpfFrequency: PlayerSettingService.FILTER_FREQUENCY_HPF_DEFAULT,
+      hpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
       enableLpf: false,
-      lpfFrequency: PlayerSettingService.FILTER_FREQUENCY_LPF_DEFAULT,
+      lpfFrequency: PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
       matchFilterFrequencyToSpectrogram: false,
     };
   });
 
   // volumeUnitDb
   test("volumeUnitDb should be false if no default value is provided", () => {
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.volumeUnitDb).toBe(false);
   });
   test("volumeUnitDb should be true if default value is true", () => {
     defaultSettings.volumeUnitDb = true;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.volumeUnitDb).toBe(true);
   });
   test("volumeUnitDb should be false if default value is false", () => {
     defaultSettings.volumeUnitDb = false;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.volumeUnitDb).toBe(false);
   });
 
   // initialVolumeDb
   test("initialVolumeDb should be 0.0 if no default value is provided", () => {
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.initialVolumeDb).toBe(0.0);
   });
   test("initialVolumeDb should be default value", () => {
     defaultSettings.initialVolumeDb = -20.0;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.initialVolumeDb).toBe(-20.0);
   });
   test("initialVolumeDb should be in valid range (check lower limit)", () => {
     defaultSettings.initialVolumeDb = -100.0;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
-    expect(ps.initialVolumeDb).toBe(PlayerSettingService.VOLUME_DB_MAX);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    expect(ps.initialVolumeDb).toBe(PlayerSettingsService.VOLUME_DB_MAX);
   });
   test("initialVolumeDb should be in valid range (check upper limit)", () => {
     defaultSettings.initialVolumeDb = 10.0;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
-    expect(ps.initialVolumeDb).toBe(PlayerSettingService.VOLUME_DB_MAX);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    expect(ps.initialVolumeDb).toBe(PlayerSettingsService.VOLUME_DB_MAX);
   });
 
   // initialVolume
   test("initialVolume should be 100 if no default value is provided", () => {
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.initialVolume).toBe(100);
   });
   test("initialVolume should be default value", () => {
     defaultSettings.initialVolume = 50;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.initialVolume).toBe(50);
   });
   test("initialVolume should be in valid range (check lower limit)", () => {
     defaultSettings.initialVolume = -10;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
-    expect(ps.initialVolume).toBe(PlayerSettingService.VOLUME_MAX);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    expect(ps.initialVolume).toBe(PlayerSettingsService.VOLUME_MAX);
   });
   test("initialVolume should be in valid range (check upper limit)", () => {
     defaultSettings.initialVolume = 200;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
-    expect(ps.initialVolume).toBe(PlayerSettingService.VOLUME_MAX);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    expect(ps.initialVolume).toBe(PlayerSettingsService.VOLUME_MAX);
   });
 
   // enableSpacekeyPlay
   test("enableSpacekeyPlay should be true if no default value is provided", () => {
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.enableSpacekeyPlay).toBe(true);
   });
   test("enableSpacekeyPlay should be true if default value is true", () => {
     defaultSettings.enableSpacekeyPlay = true;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.enableSpacekeyPlay).toBe(true);
   });
   test("enableSpacekeyPlay should be false if default value is false", () => {
     defaultSettings.enableSpacekeyPlay = false;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.enableSpacekeyPlay).toBe(false);
   });
 
   // enableSeekToPlay
   test("enableSeekToPlay should be true if no default value is provided", () => {
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.enableSeekToPlay).toBe(true);
   });
   test("enableSeekToPlay should be true if default value is true", () => {
     defaultSettings.enableSeekToPlay = true;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.enableSeekToPlay).toBe(true);
   });
   test("enableSeekToPlay should be false if default value is false", () => {
     defaultSettings.enableSeekToPlay = false;
-    const ps = PlayerSettingService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
     expect(ps.enableSeekToPlay).toBe(false);
   });
 });

--- a/src/webview/services/playerSettingsService.test.ts
+++ b/src/webview/services/playerSettingsService.test.ts
@@ -1,9 +1,13 @@
+import { createAudioContext } from "../../__mocks__/helper";
 import { PlayerDefault } from "../../config";
 import PlayerSettingsService from "./playerSettingsService";
 
 describe("playerSettingsService", () => {
+  let audioBuffer: AudioBuffer;
   let defaultSettings: PlayerDefault;
   beforeEach(() => {
+    const audioContext = createAudioContext(44100);
+    audioBuffer = audioContext.createBuffer(2, 44100, 44100);
     defaultSettings = {
       volumeUnitDb: undefined,
       initialVolumeDb: undefined,
@@ -20,91 +24,91 @@ describe("playerSettingsService", () => {
 
   // volumeUnitDb
   test("volumeUnitDb should be false if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.volumeUnitDb).toBe(false);
   });
   test("volumeUnitDb should be true if default value is true", () => {
     defaultSettings.volumeUnitDb = true;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.volumeUnitDb).toBe(true);
   });
   test("volumeUnitDb should be false if default value is false", () => {
     defaultSettings.volumeUnitDb = false;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.volumeUnitDb).toBe(false);
   });
 
   // initialVolumeDb
   test("initialVolumeDb should be 0.0 if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolumeDb).toBe(0.0);
   });
   test("initialVolumeDb should be default value", () => {
     defaultSettings.initialVolumeDb = -20.0;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolumeDb).toBe(-20.0);
   });
   test("initialVolumeDb should be in valid range (check lower limit)", () => {
     defaultSettings.initialVolumeDb = -100.0;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolumeDb).toBe(PlayerSettingsService.VOLUME_DB_MAX);
   });
   test("initialVolumeDb should be in valid range (check upper limit)", () => {
     defaultSettings.initialVolumeDb = 10.0;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolumeDb).toBe(PlayerSettingsService.VOLUME_DB_MAX);
   });
 
   // initialVolume
   test("initialVolume should be 100 if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolume).toBe(100);
   });
   test("initialVolume should be default value", () => {
     defaultSettings.initialVolume = 50;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolume).toBe(50);
   });
   test("initialVolume should be in valid range (check lower limit)", () => {
     defaultSettings.initialVolume = -10;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolume).toBe(PlayerSettingsService.VOLUME_MAX);
   });
   test("initialVolume should be in valid range (check upper limit)", () => {
     defaultSettings.initialVolume = 200;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.initialVolume).toBe(PlayerSettingsService.VOLUME_MAX);
   });
 
   // enableSpacekeyPlay
   test("enableSpacekeyPlay should be true if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.enableSpacekeyPlay).toBe(true);
   });
   test("enableSpacekeyPlay should be true if default value is true", () => {
     defaultSettings.enableSpacekeyPlay = true;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.enableSpacekeyPlay).toBe(true);
   });
   test("enableSpacekeyPlay should be false if default value is false", () => {
     defaultSettings.enableSpacekeyPlay = false;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.enableSpacekeyPlay).toBe(false);
   });
 
   // enableSeekToPlay
   test("enableSeekToPlay should be true if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.enableSeekToPlay).toBe(true);
   });
   test("enableSeekToPlay should be true if default value is true", () => {
     defaultSettings.enableSeekToPlay = true;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.enableSeekToPlay).toBe(true);
   });
   test("enableSeekToPlay should be false if default value is false", () => {
     defaultSettings.enableSeekToPlay = false;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings);
+    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
     expect(ps.enableSeekToPlay).toBe(false);
   });
 });

--- a/src/webview/services/playerSettingsService.test.ts
+++ b/src/webview/services/playerSettingsService.test.ts
@@ -24,91 +24,142 @@ describe("playerSettingsService", () => {
 
   // volumeUnitDb
   test("volumeUnitDb should be false if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.volumeUnitDb).toBe(false);
   });
   test("volumeUnitDb should be true if default value is true", () => {
     defaultSettings.volumeUnitDb = true;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.volumeUnitDb).toBe(true);
   });
   test("volumeUnitDb should be false if default value is false", () => {
     defaultSettings.volumeUnitDb = false;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.volumeUnitDb).toBe(false);
   });
 
   // initialVolumeDb
   test("initialVolumeDb should be 0.0 if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolumeDb).toBe(0.0);
   });
   test("initialVolumeDb should be default value", () => {
     defaultSettings.initialVolumeDb = -20.0;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolumeDb).toBe(-20.0);
   });
   test("initialVolumeDb should be in valid range (check lower limit)", () => {
     defaultSettings.initialVolumeDb = -100.0;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolumeDb).toBe(PlayerSettingsService.VOLUME_DB_MAX);
   });
   test("initialVolumeDb should be in valid range (check upper limit)", () => {
     defaultSettings.initialVolumeDb = 10.0;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolumeDb).toBe(PlayerSettingsService.VOLUME_DB_MAX);
   });
 
   // initialVolume
   test("initialVolume should be 100 if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolume).toBe(100);
   });
   test("initialVolume should be default value", () => {
     defaultSettings.initialVolume = 50;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolume).toBe(50);
   });
   test("initialVolume should be in valid range (check lower limit)", () => {
     defaultSettings.initialVolume = -10;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolume).toBe(PlayerSettingsService.VOLUME_MAX);
   });
   test("initialVolume should be in valid range (check upper limit)", () => {
     defaultSettings.initialVolume = 200;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.initialVolume).toBe(PlayerSettingsService.VOLUME_MAX);
   });
 
   // enableSpacekeyPlay
   test("enableSpacekeyPlay should be true if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.enableSpacekeyPlay).toBe(true);
   });
   test("enableSpacekeyPlay should be true if default value is true", () => {
     defaultSettings.enableSpacekeyPlay = true;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.enableSpacekeyPlay).toBe(true);
   });
   test("enableSpacekeyPlay should be false if default value is false", () => {
     defaultSettings.enableSpacekeyPlay = false;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.enableSpacekeyPlay).toBe(false);
   });
 
   // enableSeekToPlay
   test("enableSeekToPlay should be true if no default value is provided", () => {
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.enableSeekToPlay).toBe(true);
   });
   test("enableSeekToPlay should be true if default value is true", () => {
     defaultSettings.enableSeekToPlay = true;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.enableSeekToPlay).toBe(true);
   });
   test("enableSeekToPlay should be false if default value is false", () => {
     defaultSettings.enableSeekToPlay = false;
-    const ps = PlayerSettingsService.fromDefaultSetting(defaultSettings, audioBuffer);
+    const ps = PlayerSettingsService.fromDefaultSetting(
+      defaultSettings,
+      audioBuffer,
+    );
     expect(ps.enableSeekToPlay).toBe(false);
   });
 });

--- a/src/webview/services/playerSettingsService.test.ts
+++ b/src/webview/services/playerSettingsService.test.ts
@@ -10,6 +10,11 @@ describe("playerSettingsService", () => {
       initialVolume: undefined,
       enableSpacekeyPlay: true,
       enableSeekToPlay: true,
+      enableHpf: false,
+      hpfFrequency: PlayerSettingService.FILTER_FREQUENCY_HPF_DEFAULT,
+      enableLpf: false,
+      lpfFrequency: PlayerSettingService.FILTER_FREQUENCY_LPF_DEFAULT,
+      matchFilterFrequencyToSpectrogram: false,
     };
   });
 

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -146,9 +146,18 @@ export default class PlayerSettingsService extends Service {
   public get matchFilterFrequencyToSpectrogram() {
     return this._matchFilterFrequencyToSpectrogram;
   }
-  public set matchFilterFrequencyToSpectrogram(value: boolean) {
-    this._matchFilterFrequencyToSpectrogram =
-      value === undefined ? false : value; // false by default
+  public set matchFilterFrequencyToSpectrogram(value: boolean) 
+  {
+    const newValue = value === undefined ? false : value; // false by default
+
+    if (this._matchFilterFrequencyToSpectrogram !== newValue) {
+      this._matchFilterFrequencyToSpectrogram = newValue;
+      this.dispatchEvent(
+        new CustomEvent(EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM, {
+          detail: { value: this._matchFilterFrequencyToSpectrogram },
+        }),
+      );
+    }
   }
 
   private constructor(

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -69,16 +69,12 @@ export default class PlayerSettingsService extends Service {
     return this._enableHpf;
   }
   public set enableHpf(value: boolean) {
-    const newValue = value === undefined ? false : value; // false by default
-
-    if (this._enableHpf !== newValue) {
-      this._enableHpf = newValue;
-      this.dispatchEvent(
-        new CustomEvent(EventType.PS_UPDATE_ENABLE_HPF, {
-          detail: { value: this._enableHpf },
-        }),
-      );
-    }
+    this._enableHpf = value === undefined ? false : value; // false by default
+    this.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_ENABLE_HPF, {
+        detail: { value: this._enableHpf },
+      }),
+    );
   }
 
   private _hpfFrequency: number;
@@ -86,21 +82,17 @@ export default class PlayerSettingsService extends Service {
     return this._hpfFrequency;
   }
   public set hpfFrequency(value: number) {
-    const newValue = getLimitedValueInRange(
+    this._hpfFrequency = getLimitedValueInRange(
       value,
       PlayerSettingsService.FILTER_FREQUENCY_MIN,
       this._sampleRate / 2,
       PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
     );
-
-    if (this._hpfFrequency !== newValue || value !== newValue) {
-      this._hpfFrequency = newValue;
-      this.dispatchEvent(
-        new CustomEvent(EventType.PS_UPDATE_HPF_FREQUENCY, {
-          detail: { value: this._hpfFrequency },
-        }),
-      );
-    }
+    this.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_HPF_FREQUENCY, {
+        detail: { value: this._hpfFrequency },
+      }),
+    );
   }
 
   private _enableLpf: boolean;
@@ -108,16 +100,12 @@ export default class PlayerSettingsService extends Service {
     return this._enableLpf;
   }
   public set enableLpf(value: boolean) {
-    const newValue = value === undefined ? false : value; // false by default
-
-    if (this._enableLpf !== newValue) {
-      this._enableLpf = newValue;
-      this.dispatchEvent(
-        new CustomEvent(EventType.PS_UPDATE_ENABLE_LPF, {
-          detail: { value: this._enableLpf },
-        }),
-      );
-    }
+    this._enableLpf = value === undefined ? false : value; // false by default
+    this.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_ENABLE_LPF, {
+        detail: { value: this._enableLpf },
+      }),
+    );
   }
 
   private _lpfFrequency: number;
@@ -125,21 +113,17 @@ export default class PlayerSettingsService extends Service {
     return this._lpfFrequency;
   }
   public set lpfFrequency(value: number) {
-    const newValue = getLimitedValueInRange(
+    this._lpfFrequency = getLimitedValueInRange(
       value,
       PlayerSettingsService.FILTER_FREQUENCY_MIN,
       this._sampleRate / 2,
       PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
     );
-
-    if (this._lpfFrequency !== newValue || value !== newValue) {
-      this._lpfFrequency = newValue;
-      this.dispatchEvent(
-        new CustomEvent(EventType.PS_UPDATE_LPF_FREQUENCY, {
-          detail: { value: this._lpfFrequency },
-        }),
-      );
-    }
+    this.dispatchEvent(
+      new CustomEvent(EventType.PS_UPDATE_LPF_FREQUENCY, {
+        detail: { value: this._lpfFrequency },
+      }),
+    );
   }
 
   private _matchFilterFrequencyToSpectrogram: boolean;
@@ -147,19 +131,15 @@ export default class PlayerSettingsService extends Service {
     return this._matchFilterFrequencyToSpectrogram;
   }
   public set matchFilterFrequencyToSpectrogram(value: boolean) {
-    const newValue = value === undefined ? false : value; // false by default
-
-    if (this._matchFilterFrequencyToSpectrogram !== newValue) {
-      this._matchFilterFrequencyToSpectrogram = newValue;
-      this.dispatchEvent(
-        new CustomEvent(
-          EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
-          {
-            detail: { value: this._matchFilterFrequencyToSpectrogram },
-          },
-        ),
-      );
-    }
+    this._matchFilterFrequencyToSpectrogram = value === undefined ? false : value; // false by default
+    this.dispatchEvent(
+      new CustomEvent(
+        EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
+        {
+          detail: { value: this._matchFilterFrequencyToSpectrogram },
+        },
+      ),
+    );
   }
 
   private constructor(

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -93,7 +93,7 @@ export default class PlayerSettingsService extends Service {
       PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
     );
 
-    if (this._hpfFrequency !== newValue) {
+    if (this._hpfFrequency !== newValue || value !== newValue) {
       this._hpfFrequency = newValue;
       this.dispatchEvent(
         new CustomEvent(EventType.PS_UPDATE_HPF_FREQUENCY, {
@@ -132,7 +132,7 @@ export default class PlayerSettingsService extends Service {
       PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
     );
 
-    if (this._lpfFrequency !== newValue) {
+    if (this._lpfFrequency !== newValue || value !== newValue) {
       this._lpfFrequency = newValue;
       this.dispatchEvent(
         new CustomEvent(EventType.PS_UPDATE_LPF_FREQUENCY, {

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -146,16 +146,18 @@ export default class PlayerSettingsService extends Service {
   public get matchFilterFrequencyToSpectrogram() {
     return this._matchFilterFrequencyToSpectrogram;
   }
-  public set matchFilterFrequencyToSpectrogram(value: boolean) 
-  {
+  public set matchFilterFrequencyToSpectrogram(value: boolean) {
     const newValue = value === undefined ? false : value; // false by default
 
     if (this._matchFilterFrequencyToSpectrogram !== newValue) {
       this._matchFilterFrequencyToSpectrogram = newValue;
       this.dispatchEvent(
-        new CustomEvent(EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM, {
-          detail: { value: this._matchFilterFrequencyToSpectrogram },
-        }),
+        new CustomEvent(
+          EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,
+          {
+            detail: { value: this._matchFilterFrequencyToSpectrogram },
+          },
+        ),
       );
     }
   }

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -1,4 +1,3 @@
-import { EventType } from "../events";
 import { PlayerDefault } from "../../config";
 import { getValueInRange } from "../../util";
 import Service from "../service";

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -131,7 +131,8 @@ export default class PlayerSettingsService extends Service {
     return this._matchFilterFrequencyToSpectrogram;
   }
   public set matchFilterFrequencyToSpectrogram(value: boolean) {
-    this._matchFilterFrequencyToSpectrogram = value === undefined ? false : value; // false by default
+    this._matchFilterFrequencyToSpectrogram =
+      value === undefined ? false : value; // false by default
     this.dispatchEvent(
       new CustomEvent(
         EventType.PS_UPDATE_MATCH_FILTER_FREQUENCY_TO_SPECTROGRAM,

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -1,11 +1,17 @@
+import { EventType } from "../events";
 import { PlayerDefault } from "../../config";
 import { getValueInRange } from "../../util";
+import Service from "../service";
 
-export default class PlayerSettingsService {
+export default class PlayerSettingsService extends Service{
   public static readonly VOLUME_DB_MAX = 0.0;
   public static readonly VOLUME_DB_MIN = -80.0;
   public static readonly VOLUME_MAX = 100;
   public static readonly VOLUME_MIN = 0;
+  public static readonly FILTER_FREQUENCY_MAX = 100000;
+  public static readonly FILTER_FREQUENCY_MIN = 1;
+  public static readonly FILTER_FREQUENCY_HPF_DEFAULT = 100;
+  public static readonly FILTER_FREQUENCY_LPF_DEFAULT = 10000;
 
   private _volumeUnitDb: boolean;
   public get volumeUnitDb() {
@@ -57,23 +63,86 @@ export default class PlayerSettingsService {
     this._enableSeekToPlay = value === undefined ? true : value; // true by default
   }
 
+  private _enableHpf: boolean;
+  public get enableHpf() {
+    return this._enableHpf;
+  }
+  public set enableHpf(value: boolean) {
+    this._enableHpf = value === undefined ? false : value; // false by default
+  }
+
+  private _hpfFrequency: number;
+  public get hpfFrequency() {
+    return this._hpfFrequency;
+  }
+  public set hpfFrequency(value: number) {
+    this._hpfFrequency = getValueInRange(
+      value,
+      PlayerSettingsService.FILTER_FREQUENCY_MIN,
+      PlayerSettingsService.FILTER_FREQUENCY_MAX,
+      PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
+    );
+  }
+
+  private _enableLpf: boolean;
+  public get enableLpf() {
+    return this._enableLpf;
+  }
+  public set enableLpf(value: boolean) {
+    this._enableLpf = value === undefined ? false : value; // false by default
+  }
+
+  private _lpfFrequency: number;
+  public get lpfFrequency() {
+    return this._lpfFrequency;
+  }
+  public set lpfFrequency(value: number) {
+    this._lpfFrequency = getValueInRange(
+      value,
+      PlayerSettingsService.FILTER_FREQUENCY_MIN,
+      PlayerSettingsService.FILTER_FREQUENCY_MAX,
+      PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
+    );
+  }
+
+  private _matchFilterFrequencyToSpectrogram: boolean;
+  public get matchFilterFrequencyToSpectrogram() {
+    return this._matchFilterFrequencyToSpectrogram;
+  }
+  public set matchFilterFrequencyToSpectrogram(value: boolean) {
+    this._matchFilterFrequencyToSpectrogram = value === undefined ? false : value; // false by default
+  }
+
   private constructor(
     volumeUnitDb: boolean,
     initialVolumeDb: number,
     initialVolume: number,
     enableSpacekeyPlay: boolean,
     enableSeekToPlay: boolean,
+    enableHpf: boolean,
+    hpfFrequency: number,
+    enableLpf: boolean,
+    lpfFrequency: number,
+    matchFilterFrequencyToSpectrogram: boolean,
   ) {
+    super();
     this._volumeUnitDb = volumeUnitDb;
     this._initialVolumeDb = initialVolumeDb;
     this._initialVolume = initialVolume;
     this._enableSpacekeyPlay = enableSpacekeyPlay;
     this._enableSeekToPlay = enableSeekToPlay;
+    this._enableHpf = enableHpf;
+    this._hpfFrequency = hpfFrequency;
+    this._enableLpf = enableLpf;
+    this._lpfFrequency = lpfFrequency;
+    this._matchFilterFrequencyToSpectrogram = matchFilterFrequencyToSpectrogram;
   }
 
   public static fromDefaultSetting(defaultSetting: PlayerDefault) {
     // create instance
-    const setting = new PlayerSettingsService(true, 0.0, 1.0, true, true);
+    const setting = new PlayerSettingsService(true, 0.0, 1.0, true, true,
+                                              false, this.FILTER_FREQUENCY_HPF_DEFAULT,
+                                              false, this.FILTER_FREQUENCY_LPF_DEFAULT, false);
 
     // init volume unit
     setting.volumeUnitDb = defaultSetting.volumeUnitDb;
@@ -87,6 +156,13 @@ export default class PlayerSettingsService {
 
     // init seek to play
     setting.enableSeekToPlay = defaultSetting.enableSeekToPlay;
+
+    // init filters
+    setting.enableHpf = defaultSetting.enableHpf;
+    setting.hpfFrequency = defaultSetting.hpfFrequency;
+    setting.enableLpf = defaultSetting.enableLpf;
+    setting.lpfFrequency = defaultSetting.lpfFrequency;
+    setting.matchFilterFrequencyToSpectrogram = defaultSetting.matchFilterFrequencyToSpectrogram;
 
     return setting;
   }

--- a/src/webview/services/playerSettingsService.ts
+++ b/src/webview/services/playerSettingsService.ts
@@ -3,7 +3,7 @@ import { getValueInRange, getLimitedValueInRange } from "../../util";
 import Service from "../service";
 import { EventType } from "../events";
 
-export default class PlayerSettingsService extends Service{
+export default class PlayerSettingsService extends Service {
   public static readonly VOLUME_DB_MAX = 0.0;
   public static readonly VOLUME_DB_MIN = -80.0;
   public static readonly VOLUME_MAX = 100;
@@ -77,7 +77,7 @@ export default class PlayerSettingsService extends Service{
         new CustomEvent(EventType.PS_UPDATE_ENABLE_HPF, {
           detail: { value: this._enableHpf },
         }),
-      );  
+      );
     }
   }
 
@@ -87,10 +87,10 @@ export default class PlayerSettingsService extends Service{
   }
   public set hpfFrequency(value: number) {
     const newValue = getLimitedValueInRange(
-      value, 
-      PlayerSettingsService.FILTER_FREQUENCY_MIN, 
+      value,
+      PlayerSettingsService.FILTER_FREQUENCY_MIN,
       this._sampleRate / 2,
-      PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT
+      PlayerSettingsService.FILTER_FREQUENCY_HPF_DEFAULT,
     );
 
     if (this._hpfFrequency !== newValue) {
@@ -116,7 +116,7 @@ export default class PlayerSettingsService extends Service{
         new CustomEvent(EventType.PS_UPDATE_ENABLE_LPF, {
           detail: { value: this._enableLpf },
         }),
-      );  
+      );
     }
   }
 
@@ -126,10 +126,10 @@ export default class PlayerSettingsService extends Service{
   }
   public set lpfFrequency(value: number) {
     const newValue = getLimitedValueInRange(
-      value, 
-      PlayerSettingsService.FILTER_FREQUENCY_MIN, 
+      value,
+      PlayerSettingsService.FILTER_FREQUENCY_MIN,
       this._sampleRate / 2,
-      PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT
+      PlayerSettingsService.FILTER_FREQUENCY_LPF_DEFAULT,
     );
 
     if (this._lpfFrequency !== newValue) {
@@ -147,7 +147,8 @@ export default class PlayerSettingsService extends Service{
     return this._matchFilterFrequencyToSpectrogram;
   }
   public set matchFilterFrequencyToSpectrogram(value: boolean) {
-    this._matchFilterFrequencyToSpectrogram = value === undefined ? false : value; // false by default
+    this._matchFilterFrequencyToSpectrogram =
+      value === undefined ? false : value; // false by default
   }
 
   private constructor(
@@ -175,11 +176,23 @@ export default class PlayerSettingsService extends Service{
     this._matchFilterFrequencyToSpectrogram = matchFilterFrequencyToSpectrogram;
   }
 
-  public static fromDefaultSetting(defaultSetting: PlayerDefault, audioBuffer: AudioBuffer) {
+  public static fromDefaultSetting(
+    defaultSetting: PlayerDefault,
+    audioBuffer: AudioBuffer,
+  ) {
     // create instance
-    const setting = new PlayerSettingsService(true, 0.0, 1.0, true, true,
-                                              false, this.FILTER_FREQUENCY_HPF_DEFAULT,
-                                              false, this.FILTER_FREQUENCY_LPF_DEFAULT, false);
+    const setting = new PlayerSettingsService(
+      true,
+      0.0,
+      1.0,
+      true,
+      true,
+      false,
+      this.FILTER_FREQUENCY_HPF_DEFAULT,
+      false,
+      this.FILTER_FREQUENCY_LPF_DEFAULT,
+      false,
+    );
 
     // set sample rate of audio buffer to instance
     setting._sampleRate = audioBuffer.sampleRate;
@@ -202,7 +215,8 @@ export default class PlayerSettingsService extends Service{
     setting.hpfFrequency = defaultSetting.hpfFrequency;
     setting.enableLpf = defaultSetting.enableLpf;
     setting.lpfFrequency = defaultSetting.lpfFrequency;
-    setting.matchFilterFrequencyToSpectrogram = defaultSetting.matchFilterFrequencyToSpectrogram;
+    setting.matchFilterFrequencyToSpectrogram =
+      defaultSetting.matchFilterFrequencyToSpectrogram;
 
     return setting;
   }


### PR DESCRIPTION
This PR introduces a filter function for the player.

## Purpose of Change
* To allow the user to preview the audio more precisely.
    * For audio recording use cases, the user can focus on or remove unwanted noise.
    * For music listening use cases, the user can focus on a specific instrument or vocal.

## Changes
* Added bi-quad filters for playback audio path.
    * The added filters are only inserted into the path when enabled.
* Added PlayerSettingsComponent to set the filter enable and the cutoff frequencies.
    * The user can enable the high-pass and low-pass filters individually.
    * The user can also set the cutoff frequencies.
    * By selecting the "match to spectrogram frequency range" option, the cutoff frequencies automatically match the analyzer frequency range.
        * The user can select the frequency range to preview visually by selecting a range on the spectrogram.

![pr_player_filter](https://github.com/sukumo28/vscode-audio-preview/assets/2169305/dc8a3b71-a645-4e38-a4b9-cca4c76225f8)

## Tests
* I've confirmed the changes visually, and tested the UI operations as well.
* Some tests have been added to test the new component and settings.
* The changes conform to all existing tests.

## Notes
* This PR includes the fix of const declaration which I was mentioned in #57.
* I replaced some "playerSettingService" to "playerSettingsService" for consistency.